### PR TITLE
[update]敵の物理のオンオフ切り替え

### DIFF
--- a/Assets/Scripts/Enemy/EnemyBase.cs
+++ b/Assets/Scripts/Enemy/EnemyBase.cs
@@ -70,6 +70,13 @@ public class EnemyBase : MonoBehaviour, IPoolable, IEnemy, ISpeedChange
             {
                 Debug.LogError("マテリアルをセットしてください。");
             }
+            else
+            {
+                for (int i = 0; i < _renderers.Length; i++)
+                {
+                    _renderers[i].material = _defaultMaterial;
+                }
+            }
         }
         gameObject.SetActive(true);
         _playerTransform = playerTransform;


### PR DESCRIPTION
ノックバック以外で物理オフに切り替えるのと、
敵をオブジェクトプールで管理してる影響で、新しくスポーンされた敵がスタン状態で生成されるバグを修正。初期化時にフラグを折る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 敵がスタン中・ノックバック中に受ける物理挙動を安定化し、力の適用タイミングを改善しました。
  * スタン開始前後の物理状態の復帰を明確化して挙動の乱れを軽減しました。
  * ダメージ時の視覚フィードバック適用タイミングを整理し、表示の安定性を向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->