### PR TITLE
[fix]死亡状態から初期化した時にスタン状態が回復しない問題を修正

### DIFF
--- a/Assets/Scripts/Enemy/EnemyBase.cs
+++ b/Assets/Scripts/Enemy/EnemyBase.cs
@@ -85,8 +85,8 @@ public class EnemyBase : MonoBehaviour, IPoolable, IEnemy, ISpeedChange
         _isDead = false;
         _timeSinceLastAttack = _attackInterval;
         _stunTimer = _stunInterval;
-        CureStunned();
         _agent = GetComponent<NavMeshAgent>();
+        CureStunned();
         if (_animator == null)
         {
             _animator = GetComponentInChildren<Animator>();

--- a/Assets/Scripts/Enemy/EnemyBase.cs
+++ b/Assets/Scripts/Enemy/EnemyBase.cs
@@ -143,7 +143,10 @@ public class EnemyBase : MonoBehaviour, IPoolable, IEnemy, ISpeedChange
         Debug.Log("スタン回復");
         for (int i = 0; i < _renderers.Length; i++)
         {
-            _renderers[i].material = _defaultMaterial;
+            if(_renderers[i] != null)
+            {
+                _renderers[i].material = _defaultMaterial;
+            } 
         }
     }
     public void TryAttack()

--- a/Assets/Scripts/Enemy/EnemyBase.cs
+++ b/Assets/Scripts/Enemy/EnemyBase.cs
@@ -70,13 +70,6 @@ public class EnemyBase : MonoBehaviour, IPoolable, IEnemy, ISpeedChange
             {
                 Debug.LogError("マテリアルをセットしてください。");
             }
-            else
-            {
-                for (int i = 0; i < _renderers.Length; i++)
-                {
-                    _renderers[i].material = _defaultMaterial;
-                }
-            }
         }
         InstanceManager = manager;
         gameObject.SetActive(true);
@@ -92,7 +85,7 @@ public class EnemyBase : MonoBehaviour, IPoolable, IEnemy, ISpeedChange
         _isDead = false;
         _timeSinceLastAttack = _attackInterval;
         _stunTimer = _stunInterval;
-        _isStunned = false;
+        CureStunned();
         _agent = GetComponent<NavMeshAgent>();
         if (_animator == null)
         {
@@ -103,6 +96,7 @@ public class EnemyBase : MonoBehaviour, IPoolable, IEnemy, ISpeedChange
             behaviorGraphAgent.SetVariableValue("PlayerTransform", _playerTransform);
             behaviorGraphAgent.SetVariableValue("Enemy", this);
         }
+        Debug.Log($"{nameof(EnemyBase)}: Initialized {gameObject.name} \nHP:{_currentHp}\nisStunned{_isStunned}");
     }
     private void FixedUpdate()
     {
@@ -110,20 +104,9 @@ public class EnemyBase : MonoBehaviour, IPoolable, IEnemy, ISpeedChange
         {
             Debug.Log($"{gameObject.name}がスタンから回復するまであと{_stunTimer} 秒");
             _stunTimer -= Time.fixedDeltaTime * TimeScale;
-            Debug.Log(Mathf.Abs(transform.position.y - _beforePosY));
             if (_stunTimer < 0 && Mathf.Abs(transform.position.y - _beforePosY) < 0.0001f)
             {
-                _isStunned = false;
-                if (_agent != null)
-                {
-                    _agent.enabled = true;
-                }
-                _rb.isKinematic = true;
-                Debug.Log("スタン回復");
-                for (int i = 0; i < _renderers.Length; i++)
-                {
-                    _renderers[i].material = _defaultMaterial;
-                }
+                CureStunned();
             }
             _beforePosY = transform.position.y;
         }
@@ -148,6 +131,20 @@ public class EnemyBase : MonoBehaviour, IPoolable, IEnemy, ISpeedChange
             TryAttack();
         }
         //遠ければ EnemyMove が NavMesh で追跡してくれる前提
+    }
+    private void CureStunned()
+    {
+        _isStunned = false;
+        if (_agent != null)
+        {
+            _agent.enabled = true;
+        }
+        _rb.isKinematic = true;
+        Debug.Log("スタン回復");
+        for (int i = 0; i < _renderers.Length; i++)
+        {
+            _renderers[i].material = _defaultMaterial;
+        }
     }
     public void TryAttack()
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 敵キャラクターのスタン解除処理を統一・改善しました。解除時の移動制御復帰、物理挙動の切替、表示（マテリアル）の復元がより確実に行われます。

* **その他**
  * 初期化時および挙動開始時にデバッグ出力を追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->