### PR TITLE
Playerの攻撃時に移動を行うように

### DIFF
--- a/Assets/Editor/AttackDataEditor.cs
+++ b/Assets/Editor/AttackDataEditor.cs
@@ -1,0 +1,548 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+[CustomEditor(typeof(AttackData))]
+public class AttackDataEditor : Editor
+{
+    // ---- プロパティの参照 ----
+    private SerializedProperty _attackId;
+    private SerializedProperty _attackName;
+    private SerializedProperty _mode;
+    private SerializedProperty _attackType;
+    private SerializedProperty _comboIndex;
+    private SerializedProperty _requiredCharge;
+    private SerializedProperty _damageMultiplier;
+    private SerializedProperty _attackRange;
+    private SerializedProperty _attackRadius;
+    private SerializedProperty _nextComboAttackId;
+    private SerializedProperty _enableKnockback;
+    private SerializedProperty _knockbackPower;
+    private SerializedProperty _knockbackUpward;
+    private SerializedProperty _enableHoming;
+    private SerializedProperty _homingRadius;
+    private SerializedProperty _homingAngle;
+    private SerializedProperty _homingStrength;
+    private SerializedProperty _moveType;
+    private SerializedProperty _moveDistance;
+    private SerializedProperty _moveSpeed;
+    private SerializedProperty _moveDuration;
+    private SerializedProperty _stopOnHit;
+    private SerializedProperty _isPhantom;
+
+    // ---- プレビュー設定 ----
+    private bool _showPreview = true;
+
+    /// <summary>攻撃範囲の基点オブジェクト。</summary>
+    private GameObject _previewTarget;
+
+    /// <summary>
+    /// true  = AttackExecutor の自動検索で設定された
+    /// false = ユーザーが手動で設定した
+    /// </summary>
+    private bool _isAutoTarget;
+
+    // オブジェクト未指定時の手動方向制御
+    private Vector3 _previewDirection = Vector3.forward;
+    private float _previewAngle = 0f;
+    private bool _autoRotate = false;
+    private double _lastTime;
+
+    // プレビューカラー
+    private static readonly Color AttackSphereColor = new Color(1f, 0.3f, 0.3f, 0.25f);
+    private static readonly Color AttackSphereOutline = new Color(1f, 0.2f, 0.2f, 0.9f);
+    private static readonly Color HomingColor = new Color(0.3f, 0.8f, 1f, 0.15f);
+    private static readonly Color HomingOutline = new Color(0.3f, 0.8f, 1f, 0.8f);
+    private static readonly Color MoveColor = new Color(0.3f, 1f, 0.5f, 0.9f);
+    private static readonly Color KnockbackColor = new Color(1f, 0.85f, 0.1f, 0.9f);
+
+    private void OnEnable()
+    {
+        _attackId = serializedObject.FindProperty("_attackId");
+        _attackName = serializedObject.FindProperty("_attackName");
+        _mode = serializedObject.FindProperty("_mode");
+        _attackType = serializedObject.FindProperty("_attackType");
+        _comboIndex = serializedObject.FindProperty("_comboIndex");
+        _requiredCharge = serializedObject.FindProperty("_requiredCharge");
+        _damageMultiplier = serializedObject.FindProperty("_damageMultiplier");
+        _attackRange = serializedObject.FindProperty("_attackRange");
+        _attackRadius = serializedObject.FindProperty("_attackRadius");
+        _nextComboAttackId = serializedObject.FindProperty("_nextComboAttackId");
+        _enableKnockback = serializedObject.FindProperty("_enableKnockback");
+        _knockbackPower = serializedObject.FindProperty("_knockbackPower");
+        _knockbackUpward = serializedObject.FindProperty("_knockbackUpward");
+        _enableHoming = serializedObject.FindProperty("_enableHoming");
+        _homingRadius = serializedObject.FindProperty("_homingRadius");
+        _homingAngle = serializedObject.FindProperty("_homingAngle");
+        _homingStrength = serializedObject.FindProperty("_homingStrength");
+        _moveType = serializedObject.FindProperty("_moveType");
+        _moveDistance = serializedObject.FindProperty("_moveDistance");
+        _moveSpeed = serializedObject.FindProperty("_moveSpeed");
+        _moveDuration = serializedObject.FindProperty("_moveDuration");
+        _stopOnHit = serializedObject.FindProperty("_stopOnHit");
+        _isPhantom = serializedObject.FindProperty("_isPhantom");
+
+        _lastTime = EditorApplication.timeSinceStartup;
+
+        // AttackExecutor を持つオブジェクトを自動検索
+        TryAutoFindTarget();
+
+        SceneView.duringSceneGui += OnSceneGUI;
+    }
+
+    private void OnDisable()
+    {
+        if (_autoRotate)
+            EditorApplication.update -= Repaint;
+
+        SceneView.duringSceneGui -= OnSceneGUI;
+    }
+
+    /// <summary>
+    /// シーン内の AttackExecutor を検索して _previewTarget に自動セットする。
+    /// すでに手動で設定済みの場合は上書きしない。
+    /// </summary>
+    private void TryAutoFindTarget()
+    {
+        // 手動設定済みなら上書きしない
+        if (!_isAutoTarget && _previewTarget != null) return;
+
+        var executor = Object.FindObjectOfType<AttackExecutor>();
+        if (executor != null)
+        {
+            _previewTarget = executor.gameObject;
+            _isAutoTarget = true;
+        }
+        else
+        {
+            // 見つからなかった場合は自動フラグのみリセット（手動設定は維持）
+            if (_isAutoTarget)
+            {
+                _previewTarget = null;
+                _isAutoTarget = false;
+            }
+        }
+    }
+
+    // =========================================================
+    //  Inspector GUI
+    // =========================================================
+    public override void OnInspectorGUI()
+    {
+        serializedObject.Update();
+
+        DrawPreviewControls();
+        EditorGUILayout.Space(4);
+
+        DrawDefaultInspector();
+
+        serializedObject.ApplyModifiedProperties();
+
+        // 自動回転の更新（オブジェクト未指定時のみ有効）
+        if (_autoRotate && _previewTarget == null)
+        {
+            double now = EditorApplication.timeSinceStartup;
+            float dt = (float)(now - _lastTime);
+            _lastTime = now;
+            _previewAngle = (_previewAngle + dt * 60f) % 360f;
+            _previewDirection = Quaternion.Euler(0, _previewAngle, 0) * Vector3.forward;
+            Repaint();
+            SceneView.RepaintAll();
+        }
+    }
+
+    // =========================================================
+    //  Inspector 上部のプレビューコントロール
+    // =========================================================
+    private void DrawPreviewControls()
+    {
+        EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+
+        // タイトル行
+        EditorGUILayout.BeginHorizontal();
+        GUILayout.Label("⚔  攻撃範囲プレビュー", EditorStyles.boldLabel);
+        GUILayout.FlexibleSpace();
+        _showPreview = GUILayout.Toggle(
+            _showPreview, _showPreview ? "表示中" : "非表示",
+            "Button", GUILayout.Width(60));
+        EditorGUILayout.EndHorizontal();
+
+        if (_showPreview)
+        {
+            EditorGUILayout.Space(2);
+
+            // ---- 基点オブジェクト ----
+            if (_isAutoTarget)
+            {
+                // 自動検索で設定済み → 読み取り専用表示 ＋ 再検索ボタン
+                DrawAutoTargetField();
+            }
+            else
+            {
+                // 手動フィールド
+                DrawManualTargetField();
+            }
+
+            // ---- 方向コントロール ----
+            if (_previewTarget != null)
+            {
+                EditorGUI.BeginDisabledGroup(true);
+                EditorGUILayout.LabelField(
+                    "方向",
+                    $"{_previewTarget.name} の transform.forward を使用");
+                EditorGUI.EndDisabledGroup();
+            }
+            else
+            {
+                DrawDirectionControls();
+            }
+
+            EditorGUILayout.Space(2);
+            DrawLegend();
+        }
+
+        EditorGUILayout.EndVertical();
+    }
+
+    /// <summary>自動検索で基点が見つかった場合の表示</summary>
+    private void DrawAutoTargetField()
+    {
+        EditorGUILayout.BeginHorizontal();
+
+        // ラベル＋アイコン
+        var labelContent = new GUIContent(
+            "基点オブジェクト",
+            "AttackExecutor を持つオブジェクトを自動検索で設定しました。");
+        EditorGUILayout.PrefixLabel(labelContent);
+
+        // 読み取り専用のオブジェクトフィールド
+        EditorGUI.BeginDisabledGroup(true);
+        EditorGUILayout.ObjectField(_previewTarget, typeof(GameObject), true);
+        EditorGUI.EndDisabledGroup();
+
+        // 手動に切り替えるボタン
+        if (GUILayout.Button("手動", GUILayout.Width(42)))
+        {
+            _isAutoTarget = false;
+            // 自動で入っていたオブジェクトを手動フィールドの初期値として引き継ぐ
+            SceneView.RepaintAll();
+        }
+
+        EditorGUILayout.EndHorizontal();
+
+        // 自動設定であることを示すヘルプボックス
+        EditorGUILayout.HelpBox(
+            "AttackExecutor を自動検索して設定しました。\n" +
+            "別のオブジェクトを使う場合は「手動」ボタンで切り替えてください。",
+            MessageType.Info);
+
+        // 再検索ボタン（シーンで差し替えたときなど）
+        if (GUILayout.Button("再検索 (AttackExecutor)"))
+        {
+            _previewTarget = null;
+            _isAutoTarget = false;
+            TryAutoFindTarget();
+            SceneView.RepaintAll();
+        }
+    }
+
+    /// <summary>手動設定フィールド</summary>
+    private void DrawManualTargetField()
+    {
+        EditorGUILayout.BeginHorizontal();
+
+        EditorGUI.BeginChangeCheck();
+        _previewTarget = (GameObject)EditorGUILayout.ObjectField(
+            new GUIContent(
+                "基点オブジェクト",
+                "シーン上のGameObjectを指定すると、\n" +
+                "そのオブジェクトの position / transform.forward を\n" +
+                "攻撃範囲の基点・方向として使用します。"),
+            _previewTarget,
+            typeof(GameObject),
+            allowSceneObjects: true);
+        if (EditorGUI.EndChangeCheck())
+        {
+            _isAutoTarget = false;
+            if (_previewTarget != null && _autoRotate)
+            {
+                _autoRotate = false;
+                EditorApplication.update -= Repaint;
+            }
+            SceneView.RepaintAll();
+        }
+
+        // 自動検索ボタン
+        if (GUILayout.Button("自動検索", GUILayout.Width(62)))
+        {
+            _previewTarget = null;
+            _isAutoTarget = false;
+            TryAutoFindTarget();
+            SceneView.RepaintAll();
+        }
+
+        EditorGUILayout.EndHorizontal();
+
+        if (_previewTarget == null)
+        {
+            EditorGUILayout.HelpBox(
+                "AttackExecutor を持つオブジェクトがシーンに存在しません。\n" +
+                "手動でオブジェクトを指定するか、シーンに配置してから「自動検索」を押してください。",
+                MessageType.Warning);
+        }
+    }
+
+    /// <summary>基点オブジェクトがない場合の方向スライダー</summary>
+    private void DrawDirectionControls()
+    {
+        EditorGUI.BeginChangeCheck();
+        _previewAngle = EditorGUILayout.Slider(
+            "プレビュー方向 (Y回転)", _previewAngle, 0f, 360f);
+        if (EditorGUI.EndChangeCheck())
+        {
+            _previewDirection = Quaternion.Euler(0, _previewAngle, 0) * Vector3.forward;
+            SceneView.RepaintAll();
+        }
+
+        EditorGUI.BeginChangeCheck();
+        _autoRotate = EditorGUILayout.Toggle("自動回転", _autoRotate);
+        if (EditorGUI.EndChangeCheck())
+        {
+            _lastTime = EditorApplication.timeSinceStartup;
+            if (_autoRotate) EditorApplication.update += Repaint;
+            else EditorApplication.update -= Repaint;
+        }
+    }
+
+    private void DrawLegend()
+    {
+        var data = (AttackData)target;
+
+        EditorGUILayout.BeginHorizontal();
+
+        DrawColorBox(AttackSphereOutline);
+        GUILayout.Label("攻撃範囲", GUILayout.Width(60));
+
+        if (data.EnableHoming)
+        {
+            DrawColorBox(HomingOutline);
+            GUILayout.Label("ホーミング", GUILayout.Width(70));
+        }
+        if ((AttackMoveType)_moveType.enumValueIndex != AttackMoveType.None)
+        {
+            DrawColorBox(MoveColor);
+            GUILayout.Label("移動", GUILayout.Width(36));
+        }
+        if (data.EnableKnockback)
+        {
+            DrawColorBox(KnockbackColor);
+            GUILayout.Label("ノックバック", GUILayout.Width(76));
+        }
+
+        EditorGUILayout.EndHorizontal();
+    }
+
+    private static void DrawColorBox(Color c)
+    {
+        var rect = GUILayoutUtility.GetRect(14, 14, GUILayout.Width(14), GUILayout.Height(14));
+        EditorGUI.DrawRect(rect, c);
+    }
+
+    // =========================================================
+    //  Scene GUI（シーンビュー上の描画）
+    // =========================================================
+    private void OnSceneGUI(SceneView sceneView)
+    {
+        if (!_showPreview) return;
+
+        var data = (AttackData)target;
+
+        GetPivotAndDirection(sceneView, out var pivot, out var dir);
+
+        var attackPos = pivot + dir * data.AttackRange;
+
+        Handles.matrix = Matrix4x4.identity;
+
+        DrawMovementPreview(pivot, dir, data);
+        DrawHomingPreview(pivot, dir, data);
+        DrawAttackSpherePreview(pivot, attackPos, data);
+        DrawKnockbackArrow(attackPos, dir, data);
+        DrawInfoLabel(attackPos, data);
+    }
+
+    // =========================================================
+    //  基点・方向の解決
+    // =========================================================
+    private void GetPivotAndDirection(SceneView sceneView, out Vector3 pivot, out Vector3 dir)
+    {
+        if (_previewTarget != null)
+        {
+            pivot = _previewTarget.transform.position;
+            dir = _previewTarget.transform.forward;
+            return;
+        }
+
+        // フォールバック
+        pivot = sceneView.camera.transform.position
+                + sceneView.camera.transform.forward * 5f;
+        pivot.y = 0f;
+        dir = _previewDirection;
+    }
+
+    // =========================================================
+    //  描画メソッド
+    // =========================================================
+
+    private static void DrawAttackSpherePreview(Vector3 pivot, Vector3 attackPos, AttackData data)
+    {
+        Handles.color = data.IsPhantom
+            ? new Color(0.7f, 0.3f, 1f, 0.18f)
+            : AttackSphereColor;
+        Handles.SphereHandleCap(0, attackPos, Quaternion.identity,
+            data.AttackRadius * 2f, EventType.Repaint);
+
+        Handles.color = data.IsPhantom
+            ? new Color(0.7f, 0.3f, 1f, 0.9f)
+            : AttackSphereOutline;
+        DrawWireSphere(attackPos, data.AttackRadius);
+
+        Handles.color = new Color(1f, 0.4f, 0.4f, 0.6f);
+        Handles.DrawDottedLine(pivot, attackPos, 4f);
+    }
+
+    private static void DrawHomingPreview(Vector3 pivot, Vector3 dir, AttackData data)
+    {
+        if (!data.EnableHoming) return;
+
+        float halfAngle = data.HomingAngle * 0.5f;
+
+        Handles.color = HomingColor;
+        Handles.DrawSolidArc(pivot, Vector3.up,
+            Quaternion.Euler(0, -halfAngle, 0) * dir,
+            data.HomingAngle, data.HomingRadius);
+
+        Handles.color = HomingOutline;
+        Handles.DrawWireArc(pivot, Vector3.up,
+            Quaternion.Euler(0, -halfAngle, 0) * dir,
+            data.HomingAngle, data.HomingRadius);
+        Handles.DrawLine(pivot,
+            pivot + Quaternion.Euler(0, -halfAngle, 0) * dir * data.HomingRadius);
+        Handles.DrawLine(pivot,
+            pivot + Quaternion.Euler(0, halfAngle, 0) * dir * data.HomingRadius);
+    }
+
+    private static void DrawMovementPreview(Vector3 pivot, Vector3 dir, AttackData data)
+    {
+        if (data.MoveType == AttackMoveType.None) return;
+
+        var endPos = pivot + dir * data.MoveDistance;
+
+        Handles.color = MoveColor;
+        switch (data.MoveType)
+        {
+            case AttackMoveType.Dash:
+                Handles.DrawLine(pivot, endPos);
+                DrawArrowHead(endPos, dir, 0.3f);
+                break;
+            case AttackMoveType.Step:
+                Handles.DrawLine(pivot, endPos);
+                DrawArrowHead(endPos, dir, 0.2f);
+                Handles.DrawWireDisc(pivot, Vector3.up, 0.15f);
+                break;
+            case AttackMoveType.Curve:
+                var ctrl = pivot + dir * data.MoveDistance * 0.5f
+                                 + Vector3.up * data.MoveDistance * 0.3f;
+                Handles.DrawBezier(pivot, endPos, ctrl, endPos, MoveColor, null, 2f);
+                DrawArrowHead(endPos, dir, 0.25f);
+                break;
+        }
+
+        Handles.Label(
+            Vector3.Lerp(pivot, endPos, 0.5f) + Vector3.up * 0.3f,
+            $"移動: {data.MoveDistance:F1}m",
+            GetLabelStyle(MoveColor));
+    }
+
+    private static void DrawKnockbackArrow(Vector3 attackPos, Vector3 dir, AttackData data)
+    {
+        if (!data.EnableKnockback) return;
+
+        var knockDir = (dir + Vector3.up * data.KnockbackUpward).normalized;
+        float scale = Mathf.Clamp(data.KnockbackPower * 0.1f, 0.5f, 3f);
+
+        Handles.color = KnockbackColor;
+        Handles.DrawLine(attackPos, attackPos + knockDir * scale, 3f);
+        DrawArrowHead(attackPos + knockDir * scale, knockDir, 0.2f);
+    }
+
+    private static void DrawInfoLabel(Vector3 attackPos, AttackData data)
+    {
+        var labelPos = attackPos + Vector3.up * (data.AttackRadius + 0.4f);
+
+        string phantom = data.IsPhantom ? " 【すり抜け】" : "";
+        string info = $"<b>{data.AttackName}</b>{phantom}\n"
+                    + $"射程: {data.AttackRange:F1}  半径: {data.AttackRadius:F1}\n"
+                    + $"倍率: ×{data.DamageMultiplier:F2}";
+
+        Handles.Label(labelPos, info, GetRichLabelStyle());
+    }
+
+    // =========================================================
+    //  ヘルパー
+    // =========================================================
+    private static void DrawWireSphere(Vector3 center, float radius)
+    {
+        Handles.DrawWireDisc(center, Vector3.up, radius);
+        Handles.DrawWireDisc(center, Vector3.right, radius);
+        Handles.DrawWireDisc(center, Vector3.forward, radius);
+    }
+
+    private static void DrawArrowHead(Vector3 tip, Vector3 dir, float size)
+    {
+        if (dir == Vector3.zero) return;
+        var right = Vector3.Cross(dir, Vector3.up).normalized;
+        var back = -dir;
+        Handles.DrawLine(tip, tip + (back + right) * size);
+        Handles.DrawLine(tip, tip + (back - right) * size);
+        var up = Vector3.Cross(dir, right).normalized;
+        Handles.DrawLine(tip, tip + (back + up) * size);
+        Handles.DrawLine(tip, tip + (back - up) * size);
+    }
+
+    private static GUIStyle _labelStyle;
+    private static GUIStyle GetLabelStyle(Color c)
+    {
+        _labelStyle ??= new GUIStyle(GUI.skin.label);
+        _labelStyle.normal.textColor = c;
+        _labelStyle.fontStyle = FontStyle.Bold;
+        _labelStyle.fontSize = 11;
+        return _labelStyle;
+    }
+
+    private static GUIStyle _richLabelStyle;
+    private static GUIStyle GetRichLabelStyle()
+    {
+        if (_richLabelStyle != null) return _richLabelStyle;
+        _richLabelStyle = new GUIStyle(GUI.skin.label)
+        {
+            richText = true,
+            fontSize = 11,
+            alignment = TextAnchor.UpperCenter,
+        };
+        _richLabelStyle.normal.textColor = Color.white;
+        _richLabelStyle.normal.background = MakeTex(4, 4, new Color(0, 0, 0, 0.55f));
+        _richLabelStyle.padding = new RectOffset(4, 4, 2, 2);
+        return _richLabelStyle;
+    }
+
+    private static Texture2D MakeTex(int w, int h, Color c)
+    {
+        var pix = new Color[w * h];
+        for (int i = 0; i < pix.Length; i++) pix[i] = c;
+        var tex = new Texture2D(w, h);
+        tex.SetPixels(pix);
+        tex.Apply();
+        return tex;
+    }
+}
+#endif

--- a/Assets/Editor/AttackDataEditor.cs.meta
+++ b/Assets/Editor/AttackDataEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 00aa2cce53499f64c97323bcadaaadcc

--- a/Assets/Prefab/Player/TestPlayer.prefab
+++ b/Assets/Prefab/Player/TestPlayer.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 3128502214950529574}
   - component: {fileID: 4412391866698522038}
   - component: {fileID: 2204079526448793672}
-  m_Layer: 0
+  m_Layer: 3
   m_Name: TestPlayer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -119,6 +119,9 @@ MonoBehaviour:
     Level: 1
   - TimeThreshold: 1.5
     Level: 2
+  _homingLayer:
+    serializedVersion: 2
+    m_Bits: 256
 --- !u!114 &3128502214950529574
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -133,7 +136,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::AttackExecutor
   _layer:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 256
 --- !u!114 &4412391866698522038
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -179,6 +182,66 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 4679827096331906539}
     m_Modifications:
+    - target: {fileID: 43253365438973551, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 242254991242302266, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 351631157759749229, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 702080911710210728, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 892905030279547162, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 897711141871002143, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 950298247047153863, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 977571223096470537, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 980750822879064677, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1215136715302433584, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1251766486714350466, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1406409806968939234, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1576690845631425743, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1590789574875533051, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814239837332813183, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 1961794358539717462, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
       propertyPath: m_Enabled
       value: 1
@@ -191,21 +254,149 @@ PrefabInstance:
       propertyPath: m_ApplyRootMotion
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2070248029155062765, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2162934102220931055, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2216252239838927301, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2590040271850643003, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2656921172243360591, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2671185168124778878, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2692614455283305781, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2889040873115419422, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3052581235332676318, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3211117922716133802, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3290278023527820560, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3313822462979399968, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3468885062697498453, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3613420297340743999, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3787067194612765291, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3853028382774022001, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4102424730040129202, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165544476023236666, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4193904234292795818, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4277573906312492125, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4409326986782181378, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426268349891216685, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4452688810635217181, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537466040791474718, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4542125035399982599, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4764974126583022617, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4809544433459554900, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 4873140576092103111, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -2.46421
+      value: -2.464198
       objectReference: {fileID: 0}
     - target: {fileID: 4873140576092103111, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 6.8466916
+      value: 6.8466806
       objectReference: {fileID: 0}
     - target: {fileID: 4873140576092103111, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: -99.430504
+      value: -99.4305
+      objectReference: {fileID: 0}
+    - target: {fileID: 5085212601316670912, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5085212601654021014, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
       propertyPath: m_Name
       value: Grruzam_BaseModeling_Hammer_Male (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5085212601654021014, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5105740541149066079, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287573956177877891, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5499996357125703808, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5609687742127395116, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -247,6 +438,46 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5662906447576687136, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5699944625710057981, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5732195392323238592, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5740715410267079947, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5876902789410387687, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967351064504480071, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6454836590501842921, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6547315848896866045, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6573552343045313318, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6640362853300855467, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 6742646871983807509, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
@@ -255,6 +486,78 @@ PrefabInstance:
       propertyPath: 'm_Materials.Array.data[2]'
       value: 
       objectReference: {fileID: 2100000, guid: c26bae11f499dba439460c9517351e0f, type: 2}
+    - target: {fileID: 6873787118627186552, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7103676730468805687, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7251232124320864696, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7252860222052554014, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7449294256005033128, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7452916291796277761, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7505596188183676916, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7586678804536724301, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7629860201398703426, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7728169765381989405, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7834521561760433330, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8174837818250258964, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8273425586162062908, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8365465843990463643, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8378219471083522149, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8880865220405086028, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894376641304693118, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 9207718228145858226, guid: 2d6de66be35f49d489a256e222067fcc, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scenes/TestScenes/PlayerTestScene.unity
+++ b/Assets/Scenes/TestScenes/PlayerTestScene.unity
@@ -1915,6 +1915,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3128502214950529574, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
+      propertyPath: _layer.m_Bits
+      value: 256
+      objectReference: {fileID: 0}
     - target: {fileID: 4381277416048193596, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: -2.464198
@@ -1970,6 +1974,10 @@ PrefabInstance:
     - target: {fileID: 5847551565396971007, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
       propertyPath: m_Name
       value: TestPlayer
+      objectReference: {fileID: 0}
+    - target: {fileID: 5855154594791047215, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
+      propertyPath: _homingLayer.m_Bits
+      value: 256
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/Data/Player/AttackData.cs
+++ b/Assets/Scripts/Data/Player/AttackData.cs
@@ -25,6 +25,12 @@ public class AttackData : ScriptableObject
     public float KnockbackPower => _knockbackPower;
     public float KnockbackUpward => _knockbackUpward;
 
+    public AttackMoveType MoveType => _moveType;
+    public float MoveDistance => _moveDistance;
+    public float MoveSpeed => _moveSpeed;
+    public float MoveDuration => _moveDuration;
+    public bool StopOnHit => _stopOnHit;
+
     [Header("Basic Info")]
     [SerializeField] private int _attackId;
     [SerializeField] private string _attackName;
@@ -53,6 +59,13 @@ public class AttackData : ScriptableObject
     [SerializeField] private float _homingRadius = 5f;
     [SerializeField] private float _homingAngle = 45f;
     [SerializeField] private float _homingStrength = 10f;
+
+    [Header("Movement")]
+    [SerializeField] private AttackMoveType _moveType = AttackMoveType.None;
+    [SerializeField] private float _moveDistance = 0f;
+    [SerializeField] private float _moveSpeed = 0f;
+    [SerializeField] private float _moveDuration = 0f;
+    [SerializeField] private bool _stopOnHit = true;
 }
 
 // 攻撃の段階（チャージレベル）
@@ -84,4 +97,19 @@ public enum PlayerMode
     Warrior,
     [InspectorName("雷神")]
     Thunder
+}
+
+public enum AttackMoveType
+{
+    [InspectorName("移動なし")]
+    None,   // その場
+
+    [InspectorName("突進")]
+    Dash,   // 直線突進
+
+    [InspectorName("ステップ")]
+    Step,   // 小移動
+
+    [InspectorName("曲線移動 / ホーミング")]
+    Curve,  // 曲線 / ホーミング（将来）
 }

--- a/Assets/Scripts/Data/Player/AttackData.cs
+++ b/Assets/Scripts/Data/Player/AttackData.cs
@@ -30,6 +30,7 @@ public class AttackData : ScriptableObject
     public float MoveSpeed => _moveSpeed;
     public float MoveDuration => _moveDuration;
     public bool StopOnHit => _stopOnHit;
+    public bool IsPhantom => _isPhantom;
 
     [Header("Basic Info")]
     [SerializeField] private int _attackId;
@@ -66,6 +67,7 @@ public class AttackData : ScriptableObject
     [SerializeField] private float _moveSpeed = 0f;
     [SerializeField] private float _moveDuration = 0f;
     [SerializeField] private bool _stopOnHit = true;
+    [SerializeField] private bool _isPhantom = false; // すり抜け攻撃かどうか 
 }
 
 // 攻撃の段階（チャージレベル）

--- a/Assets/Scripts/Player/AttackExecutor.cs
+++ b/Assets/Scripts/Player/AttackExecutor.cs
@@ -142,19 +142,6 @@ public class AttackExecutor : MonoBehaviour
 }
 
 /// <summary>
-/// 攻撃時の移動要求情報
-/// </summary>
-public struct AttackMoveRequest
-{
-    public AttackMoveType MoveType;
-    public float Distance;
-    public float Speed;
-    public float Duration;
-    public Vector3 Direction;
-    public bool StopOnHit;
-}
-
-/// <summary>
 /// Playerの攻撃やスキルに扱う情報
 /// </summary>
 public struct AttackContext

--- a/Assets/Scripts/Player/AttackExecutor.cs
+++ b/Assets/Scripts/Player/AttackExecutor.cs
@@ -5,9 +5,6 @@ using UnityEngine;
 
 public class AttackExecutor : MonoBehaviour
 {
-    // 攻撃時の移動要求イベント
-    public event Action<AttackMoveRequest> OnAttackMoveRequested;
-
     public void Init(IPlayerStats stats, SkillManager manager)
     {
         _playerStats = stats;
@@ -20,21 +17,6 @@ public class AttackExecutor : MonoBehaviour
     public void Execute(AttackData data, AttackInput input, ModeData modeData)
     {
         _lastAttackData = data;
-
-        // 移動要求を発行
-        if (data.MoveType != AttackMoveType.None)
-        {
-            var moveRequest = new AttackMoveRequest
-            {
-                MoveType = data.MoveType,
-                Distance = data.MoveDistance,
-                Speed = data.MoveSpeed,
-                Duration = data.MoveDuration,
-                Direction = transform.forward,
-                StopOnHit = data.StopOnHit
-            };
-            OnAttackMoveRequested?.Invoke(moveRequest);
-        }
 
         var attackPos = transform.position + transform.forward * data.AttackRange;
         var cols = Physics.OverlapSphere(attackPos, data.AttackRadius, _layer);

--- a/Assets/Scripts/Player/AttackExecutor.cs
+++ b/Assets/Scripts/Player/AttackExecutor.cs
@@ -5,12 +5,14 @@ using UnityEngine;
 
 public class AttackExecutor : MonoBehaviour
 {
+    // 攻撃時の移動要求イベント
+    public event Action<AttackMoveRequest> OnAttackMoveRequested;
+
     public void Init(IPlayerStats stats, SkillManager manager)
     {
         _playerStats = stats;
         _skillManager = manager;
     }
-
 
     /// <summary>
     /// 与えられたデータを基に攻撃
@@ -18,6 +20,21 @@ public class AttackExecutor : MonoBehaviour
     public void Execute(AttackData data, AttackInput input, ModeData modeData)
     {
         _lastAttackData = data;
+
+        // 移動要求を発行
+        if (data.MoveType != AttackMoveType.None)
+        {
+            var moveRequest = new AttackMoveRequest
+            {
+                MoveType = data.MoveType,
+                Distance = data.MoveDistance,
+                Speed = data.MoveSpeed,
+                Duration = data.MoveDuration,
+                Direction = transform.forward,
+                StopOnHit = data.StopOnHit
+            };
+            OnAttackMoveRequested?.Invoke(moveRequest);
+        }
 
         var attackPos = transform.position + transform.forward * data.AttackRange;
         var cols = Physics.OverlapSphere(attackPos, data.AttackRadius, _layer);
@@ -140,6 +157,19 @@ public class AttackExecutor : MonoBehaviour
         Gizmos.DrawLine(transform.position, pos);
     }
 #endif
+}
+
+/// <summary>
+/// 攻撃時の移動要求情報
+/// </summary>
+public struct AttackMoveRequest
+{
+    public AttackMoveType MoveType;
+    public float Distance;
+    public float Speed;
+    public float Duration;
+    public Vector3 Direction;
+    public bool StopOnHit;
 }
 
 /// <summary>

--- a/Assets/Scripts/Player/AttackExecutor.cs
+++ b/Assets/Scripts/Player/AttackExecutor.cs
@@ -64,6 +64,8 @@ public class AttackExecutor : MonoBehaviour
         context.OnAfterAttack?.Invoke();
     }
 
+
+    [SerializeField] private LayerMask _layer;
     private IPlayerStats _playerStats;
     private SkillManager _skillManager;
 
@@ -120,9 +122,6 @@ public class AttackExecutor : MonoBehaviour
             Knockback = context.Knockback
         };
     }
-
-
-    [SerializeField] private LayerMask _layer;
 
     // デバッグ用
     private AttackData _lastAttackData;

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -26,6 +26,8 @@ public class Player : MonoBehaviour, IPlayer, IStamina
 
         _attackExecutor?.Init(this, skillManager);
 
+        _attack?.Init(_playerStateManager, input, _attackExecutor, _modeController, _playerAnimationController);
+
         _move?.Init(
            _playerStateManager,
            input,
@@ -34,9 +36,7 @@ public class Player : MonoBehaviour, IPlayer, IStamina
            this,
            _modeController,
            _playerAnimationController,
-           _attackExecutor);
-
-        _attack?.Init(_playerStateManager, input, _attackExecutor, _modeController, _playerAnimationController);
+           _attack);
 
         _playerAnimationController.Init(_playerStateManager, _modeController);
     }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -33,7 +33,8 @@ public class Player : MonoBehaviour, IPlayer, IStamina
            _moveData,
            this,
            _modeController,
-           _playerAnimationController);
+           _playerAnimationController,
+           _attackExecutor);
 
         _attack?.Init(_playerStateManager, input, _attackExecutor, _modeController, _playerAnimationController);
 

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -306,6 +306,10 @@ public class PlayerAttack : MonoBehaviour
             _homingStrength = _pendingAttackData.HomingStrength;
             _homingTarget = FindHomingTarget(_homingRadius, _homingAngle);
         }
+        else
+        {
+            _homingTarget = null;
+        }
 
         // 移動要求を発行
         if (attackData.MoveType != AttackMoveType.None)

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 
 public class PlayerAttack : MonoBehaviour
 {
+    // 攻撃時の移動要求イベント
+    public event Action<AttackMoveRequest> OnAttackMoveRequested;
+
     public void Init(PlayerStateManager playerStateManager,
         InputHandler input,
         AttackExecutor executor,
@@ -300,6 +303,21 @@ public class PlayerAttack : MonoBehaviour
             _homingRadius = _pendingAttackData.HomingRadius;
             _homingAngle = _pendingAttackData.HomingAngle;
             _homingStrength = _pendingAttackData.HomingStrength;
+        }
+
+        // 移動要求を発行
+        if (attackData.MoveType != AttackMoveType.None)
+        {
+            var moveRequest = new AttackMoveRequest
+            {
+                MoveType = attackData.MoveType,
+                Distance = attackData.MoveDistance,
+                Speed = attackData.MoveSpeed,
+                Duration = attackData.MoveDuration,
+                Direction = transform.forward,
+                StopOnHit = attackData.StopOnHit
+            };
+            OnAttackMoveRequested?.Invoke(moveRequest);
         }
 
         // アニメーション再生のみ

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -315,7 +315,6 @@ public class PlayerAttack : MonoBehaviour
                 Speed = attackData.MoveSpeed,
                 Duration = attackData.MoveDuration,
                 Direction = transform.forward,
-                StopOnHit = attackData.StopOnHit
             };
             OnAttackMoveRequested?.Invoke(moveRequest);
         }
@@ -538,4 +537,16 @@ public struct AttackInput
 
         return ChargeLevel.None;
     }
+}
+
+/// <summary>
+/// 攻撃時の移動要求情報
+/// </summary>
+public struct AttackMoveRequest
+{
+    public AttackMoveType MoveType;
+    public float Distance;
+    public float Speed;
+    public float Duration;
+    public Vector3 Direction;
 }

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -90,7 +90,7 @@ public class PlayerAttack : MonoBehaviour
         new ChargeThreshold { TimeThreshold = 1.5f, Level = ChargeLevel.Level2 }
     };
 
-    // [SerializeField] private LayerMask _homingLayer = LayerMask.GetMask("Enemy");
+    [SerializeField] private LayerMask _homingLayer;
 
     // 状態
     private int _currentAttackId = -1;
@@ -321,7 +321,8 @@ public class PlayerAttack : MonoBehaviour
                 Speed = attackData.MoveSpeed,
                 Duration = attackData.MoveDuration,
                 Target = _homingTarget,
-                StopDistance = attackData.StopOnHit ? attackData.AttackRange : 0
+                StopDistance = attackData.StopOnHit ? attackData.AttackRange : 0,
+                IsPhantom = attackData.IsPhantom
             };
             OnAttackMoveRequested?.Invoke(moveRequest);
         }
@@ -441,8 +442,7 @@ public class PlayerAttack : MonoBehaviour
 
     private Transform FindHomingTarget(float radius, float angle)
     {
-        // TODO: 敵のレイヤーを設定して、レイヤーマスクを使うようにする
-        var hits = Physics.OverlapSphere(transform.position, radius);
+        var hits = Physics.OverlapSphere(transform.position, radius, _homingLayer);
 
         Transform best = null;
         float bestScore = float.MaxValue;
@@ -556,4 +556,5 @@ public struct AttackMoveRequest
     public float Duration;
     public Transform Target; // 攻撃時の一番近い敵
     public float StopDistance; // 敵がいるときに攻撃を止める距離
+    public bool IsPhantom; // 攻撃がファントムかどうか
 }

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -103,6 +103,7 @@ public class PlayerAttack : MonoBehaviour
     private float _homingStrength;
     private float _homingRadius;
     private float _homingAngle;
+    private Transform _homingTarget;
 
     // 保留中の攻撃データ
     private AttackData _pendingAttackData;
@@ -303,6 +304,7 @@ public class PlayerAttack : MonoBehaviour
             _homingRadius = _pendingAttackData.HomingRadius;
             _homingAngle = _pendingAttackData.HomingAngle;
             _homingStrength = _pendingAttackData.HomingStrength;
+            _homingTarget = FindHomingTarget(_homingRadius, _homingAngle);
         }
 
         // 移動要求を発行
@@ -314,7 +316,8 @@ public class PlayerAttack : MonoBehaviour
                 Distance = attackData.MoveDistance,
                 Speed = attackData.MoveSpeed,
                 Duration = attackData.MoveDuration,
-                Direction = transform.forward,
+                Target = _homingTarget,
+                StopDistance = attackData.StopOnHit ? attackData.AttackRange : 0
             };
             OnAttackMoveRequested?.Invoke(moveRequest);
         }
@@ -463,10 +466,9 @@ public class PlayerAttack : MonoBehaviour
     {
         if (!_isHomingActive) { return; }
 
-        var target = FindHomingTarget(_homingRadius, _homingAngle);
-        if (target == null) { return; }
+        if (_homingTarget == null) { return; }
 
-        var dir = target.position - transform.position;
+        var dir = _homingTarget.position - transform.position;
         dir.y = 0f;
         if (dir.sqrMagnitude <= 0f) { return; }
 
@@ -548,5 +550,6 @@ public struct AttackMoveRequest
     public float Distance;
     public float Speed;
     public float Duration;
-    public Vector3 Direction;
+    public Transform Target; // 攻撃時の一番近い敵
+    public float StopDistance; // 敵がいるときに攻撃を止める距離
 }

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -59,9 +59,9 @@ public class PlayerMovement : MonoBehaviour
         {
             Move();
             Rotate();
+            PlayMoveAnimation();
         }
 
-        PlayMoveAnimation();
         UpdateDodgeChain();
     }
 

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -101,9 +101,6 @@ public class PlayerMovement : MonoBehaviour
     /// </summary>
     private async UniTaskVoid PerformAttackMove(AttackMoveRequest request)
     {
-        // すでに攻撃移動中なら新しい移動要求を無視
-        if (_isAttackMoving) { return; }
-
         _isAttackMoving = true;
 
         try

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -125,7 +125,11 @@ public class PlayerMovement : MonoBehaviour
         finally
         {
             _isAttackMoving = false;
-            _rb.linearVelocity = Vector3.zero;
+
+            if (_rb)
+            {
+                _rb.linearVelocity = Vector3.zero;
+            }
         }
     }
 
@@ -168,6 +172,8 @@ public class PlayerMovement : MonoBehaviour
         Vector3 moveDir = transform.forward;
         moveDir.y = 0;
 
+        float speed = request.Distance / request.Duration;
+
         while (true)
         {
             if (elapsed >= request.Duration) { break; }
@@ -175,7 +181,7 @@ public class PlayerMovement : MonoBehaviour
             if (request.Target &&
                 Vector3.Distance(request.Target.position, transform.position) < request.StopDistance) { break; }
 
-            _rb.linearVelocity = moveDir * request.Speed;
+            _rb.linearVelocity = moveDir * speed;
 
             elapsed += Time.deltaTime;
             await UniTask.Yield(_attackMoveCts.Token);

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -1,5 +1,6 @@
 using Cysharp.Threading.Tasks;
 using System;
+using System.Threading;
 using UnityEngine;
 
 public class PlayerMovement : MonoBehaviour
@@ -14,7 +15,8 @@ public class PlayerMovement : MonoBehaviour
         MoveData data,
         IStamina stamina,
         IModeController modeController,
-        PlayerAnimationController animationController)
+        PlayerAnimationController animationController,
+         AttackExecutor attackExecutor)
     {
         _playerStateManager = playerStateManager;
         _input = input;
@@ -25,6 +27,8 @@ public class PlayerMovement : MonoBehaviour
         _animationController = animationController;
 
         _input.OnDodge += Dodge;
+
+        _attackExecutor.OnAttackMoveRequested += HandleAttackMove;
     }
 
     [SerializeField] private Rigidbody _rb;
@@ -36,16 +40,26 @@ public class PlayerMovement : MonoBehaviour
     private IStamina _stamina;
     private IModeController _modeController;
     private PlayerAnimationController _animationController;
+    private AttackExecutor _attackExecutor;
 
     private bool _canChainRoll;
     private float _chainTimer;
+
+    // 攻撃時移動用
+    private CancellationTokenSource _attackMoveCts;
+    private bool _isAttackMoving;
 
     #region イベント関数
 
     private void Update()
     {
-        Move();
-        Rotate();
+        // 攻撃時移動中は通常移動をスキップ
+        if (!_isAttackMoving)
+        {
+            Move();
+            Rotate();
+        }
+
         PlayMoveAnimation();
         UpdateDodgeChain();
     }
@@ -56,9 +70,114 @@ public class PlayerMovement : MonoBehaviour
         {
             _input.OnDodge -= Dodge;
         }
+
+        if (_attackExecutor != null)
+        {
+            _attackExecutor.OnAttackMoveRequested -= HandleAttackMove;
+        }
+
+        _attackMoveCts?.Cancel();
+        _attackMoveCts?.Dispose();
     }
 
     #endregion
+
+    /// <summary>
+    /// 攻撃時の移動要求を処理
+    /// </summary>
+    private void HandleAttackMove(AttackMoveRequest request)
+    {
+        // 既存の攻撃移動をキャンセル
+        _attackMoveCts?.Cancel();
+        _attackMoveCts?.Dispose();
+        _attackMoveCts = new CancellationTokenSource();
+
+        PerformAttackMove(request).Forget();
+    }
+
+    /// <summary>
+    /// 攻撃時移動の実行
+    /// </summary>
+    private async UniTaskVoid PerformAttackMove(AttackMoveRequest request)
+    {
+        _isAttackMoving = true;
+
+        try
+        {
+            switch (request.MoveType)
+            {
+                case AttackMoveType.Dash:
+                    await DashMove(request);
+                    break;
+                case AttackMoveType.Step:
+                    await StepMove(request);
+                    break;
+                case AttackMoveType.Curve:
+                    await CurveMove(request);
+                    break;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // キャンセルされた場合
+        }
+        finally
+        {
+            _isAttackMoving = false;
+            _rb.linearVelocity = Vector3.zero;
+        }
+    }
+
+    /// <summary>
+    /// 突進移動
+    /// </summary>
+    private async UniTask DashMove(AttackMoveRequest request)
+    {
+        float elapsed = 0f;
+        Vector3 moveDir = request.Direction.normalized;
+        moveDir.y = 0;
+
+        while (elapsed < request.Duration)
+        {
+            _rb.linearVelocity = moveDir * request.Speed;
+
+            elapsed += Time.deltaTime;
+            await UniTask.Yield(_attackMoveCts.Token);
+        }
+    }
+
+    /// <summary>
+    /// ステップ移動（小移動）
+    /// </summary>
+    private async UniTask StepMove(AttackMoveRequest request)
+    {
+        float elapsed = 0f;
+        Vector3 startPos = transform.position;
+        Vector3 targetPos = startPos + request.Direction.normalized * request.Distance;
+        targetPos.y = startPos.y;
+
+        while (elapsed < request.Duration)
+        {
+            float t = elapsed / request.Duration;
+            // イージング（加速→減速）
+            float smoothT = Mathf.SmoothStep(0, 1, t);
+
+            Vector3 newPos = Vector3.Lerp(startPos, targetPos, smoothT);
+            _rb.linearVelocity = (newPos - transform.position) / Time.deltaTime;
+
+            elapsed += Time.deltaTime;
+            await UniTask.Yield(_attackMoveCts.Token);
+        }
+    }
+
+    /// <summary>
+    /// 曲線移動（将来的にホーミングなど）
+    /// </summary>
+    private async UniTask CurveMove(AttackMoveRequest request)
+    {
+        // 現時点では Dash と同じ実装
+        await DashMove(request);
+    }
 
     private void Move()
     {

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -101,6 +101,9 @@ public class PlayerMovement : MonoBehaviour
     /// </summary>
     private async UniTaskVoid PerformAttackMove(AttackMoveRequest request)
     {
+        // すでに攻撃移動中なら新しい移動要求を無視
+        if (_isAttackMoving) { return; }
+
         _isAttackMoving = true;
 
         try
@@ -135,11 +138,16 @@ public class PlayerMovement : MonoBehaviour
     private async UniTask DashMove(AttackMoveRequest request)
     {
         float elapsed = 0f;
-        Vector3 moveDir = request.Direction.normalized;
+        Vector3 moveDir = transform.forward;
         moveDir.y = 0;
 
-        while (elapsed < request.Duration)
+        while (true)
         {
+            if (elapsed >= request.Duration) { break; }
+
+            if (request.Target &&
+                Vector3.Distance(request.Target.position, transform.position) < request.StopDistance) { break; }
+
             _rb.linearVelocity = moveDir * request.Speed;
 
             elapsed += Time.deltaTime;
@@ -154,11 +162,17 @@ public class PlayerMovement : MonoBehaviour
     {
         float elapsed = 0f;
         Vector3 startPos = transform.position;
-        Vector3 targetPos = startPos + request.Direction.normalized * request.Distance;
+        Vector3 targetPos = startPos + transform.forward * request.Distance;
         targetPos.y = startPos.y;
 
-        while (elapsed < request.Duration)
+
+        while (true)
         {
+            if (elapsed >= request.Duration) { break; }
+
+            if (request.Target &&
+                Vector3.Distance(request.Target.position, transform.position) < request.StopDistance) { break; }
+
             float t = elapsed / request.Duration;
             // イージング（加速→減速）
             float smoothT = Mathf.SmoothStep(0, 1, t);

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -49,6 +49,7 @@ public class PlayerMovement : MonoBehaviour
     // 攻撃時移動用
     private CancellationTokenSource _attackMoveCts;
     private bool _isAttackMoving;
+    private bool _currentIsPhantom;
 
     #region イベント関数
 
@@ -92,6 +93,17 @@ public class PlayerMovement : MonoBehaviour
         _attackMoveCts?.Cancel();
         _attackMoveCts?.Dispose();
         _attackMoveCts = new CancellationTokenSource();
+
+        // 前回のファントム状態をリセット
+        if (_currentIsPhantom)
+        {
+            Physics.IgnoreLayerCollision(
+                LayerMask.NameToLayer("Player"),
+                LayerMask.NameToLayer("Enemy"),
+                false
+            );
+            _currentIsPhantom = false;
+        }
 
         PerformAttackMove(request).Forget();
     }
@@ -164,6 +176,8 @@ public class PlayerMovement : MonoBehaviour
 
         while (true)
         {
+            if (request.Duration <= 0f) { return; }
+
             if (elapsed >= request.Duration) { break; }
 
             if (request.Target &&
@@ -194,6 +208,8 @@ public class PlayerMovement : MonoBehaviour
 
         while (true)
         {
+            if (request.Duration <= 0f) { return; }
+
             if (elapsed >= request.Duration) { break; }
 
             if (request.Target &&

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -16,7 +16,7 @@ public class PlayerMovement : MonoBehaviour
         IStamina stamina,
         IModeController modeController,
         PlayerAnimationController animationController,
-         AttackExecutor attackExecutor)
+        PlayerAttack attack)
     {
         _playerStateManager = playerStateManager;
         _input = input;
@@ -25,11 +25,11 @@ public class PlayerMovement : MonoBehaviour
         _stamina = stamina;
         _modeController = modeController;
         _animationController = animationController;
-        _attackExecutor = attackExecutor;
+        _attack = attack;
 
         _input.OnDodge += Dodge;
 
-        _attackExecutor.OnAttackMoveRequested += HandleAttackMove;
+        _attack.OnAttackMoveRequested += HandleAttackMove;
     }
 
     [SerializeField] private Rigidbody _rb;
@@ -41,7 +41,7 @@ public class PlayerMovement : MonoBehaviour
     private IStamina _stamina;
     private IModeController _modeController;
     private PlayerAnimationController _animationController;
-    private AttackExecutor _attackExecutor;
+    private PlayerAttack _attack;
 
     private bool _canChainRoll;
     private float _chainTimer;
@@ -72,9 +72,9 @@ public class PlayerMovement : MonoBehaviour
             _input.OnDodge -= Dodge;
         }
 
-        if (_attackExecutor != null)
+        if (_attack != null)
         {
-            _attackExecutor.OnAttackMoveRequested -= HandleAttackMove;
+            _attack.OnAttackMoveRequested -= HandleAttackMove;
         }
 
         _attackMoveCts?.Cancel();

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -154,13 +154,14 @@ public class PlayerMovement : MonoBehaviour
                 _rb.linearVelocity = Vector3.zero;
             }
 
-            if (request.IsPhantom)
+            if (_currentIsPhantom)
             {
                 Physics.IgnoreLayerCollision(
                     LayerMask.NameToLayer("Player"),
                     LayerMask.NameToLayer("Enemy"),
                     false
                 );
+                _currentIsPhantom = false;
             }
         }
     }

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -138,29 +138,6 @@ public class PlayerMovement : MonoBehaviour
     private async UniTask DashMove(AttackMoveRequest request)
     {
         float elapsed = 0f;
-        Vector3 moveDir = transform.forward;
-        moveDir.y = 0;
-
-        while (true)
-        {
-            if (elapsed >= request.Duration) { break; }
-
-            if (request.Target &&
-                Vector3.Distance(request.Target.position, transform.position) < request.StopDistance) { break; }
-
-            _rb.linearVelocity = moveDir * request.Speed;
-
-            elapsed += Time.deltaTime;
-            await UniTask.Yield(_attackMoveCts.Token);
-        }
-    }
-
-    /// <summary>
-    /// ステップ移動（小移動）
-    /// </summary>
-    private async UniTask StepMove(AttackMoveRequest request)
-    {
-        float elapsed = 0f;
         Vector3 startPos = transform.position;
         Vector3 targetPos = startPos + transform.forward * request.Distance;
         targetPos.y = startPos.y;
@@ -179,6 +156,29 @@ public class PlayerMovement : MonoBehaviour
 
             Vector3 newPos = Vector3.Lerp(startPos, targetPos, smoothT);
             _rb.linearVelocity = (newPos - transform.position) / Time.deltaTime;
+
+            elapsed += Time.deltaTime;
+            await UniTask.Yield(_attackMoveCts.Token);
+        }
+    }
+
+    /// <summary>
+    /// ステップ移動（小移動）
+    /// </summary>
+    private async UniTask StepMove(AttackMoveRequest request)
+    {
+        float elapsed = 0f;
+        Vector3 moveDir = transform.forward;
+        moveDir.y = 0;
+
+        while (true)
+        {
+            if (elapsed >= request.Duration) { break; }
+
+            if (request.Target &&
+                Vector3.Distance(request.Target.position, transform.position) < request.StopDistance) { break; }
+
+            _rb.linearVelocity = moveDir * request.Speed;
 
             elapsed += Time.deltaTime;
             await UniTask.Yield(_attackMoveCts.Token);

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -117,6 +117,8 @@ public class PlayerMovement : MonoBehaviour
 
         if (request.IsPhantom)
         {
+            _currentIsPhantom = true;
+
             Physics.IgnoreLayerCollision(
             LayerMask.NameToLayer("Player"),
             LayerMask.NameToLayer("Enemy"),

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -25,6 +25,7 @@ public class PlayerMovement : MonoBehaviour
         _stamina = stamina;
         _modeController = modeController;
         _animationController = animationController;
+        _attackExecutor = attackExecutor;
 
         _input.OnDodge += Dodge;
 

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -103,6 +103,15 @@ public class PlayerMovement : MonoBehaviour
     {
         _isAttackMoving = true;
 
+        if (request.IsPhantom)
+        {
+            Physics.IgnoreLayerCollision(
+            LayerMask.NameToLayer("Player"),
+            LayerMask.NameToLayer("Enemy"),
+            true
+        );
+        }
+
         try
         {
             switch (request.MoveType)
@@ -129,6 +138,15 @@ public class PlayerMovement : MonoBehaviour
             if (_rb)
             {
                 _rb.linearVelocity = Vector3.zero;
+            }
+
+            if (request.IsPhantom)
+            {
+                Physics.IgnoreLayerCollision(
+                    LayerMask.NameToLayer("Player"),
+                    LayerMask.NameToLayer("Enemy"),
+                    false
+                );
             }
         }
     }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -13,7 +13,7 @@ TagManager:
   - UI
   - Interact
   - Ground
-  - 
+  - Enemy
   - 
   - 
   - 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 攻撃に連動する移動を追加（ダッシュ・ステップ・カーブ）
  * 攻撃開始前に移動要求が発行され、外部システムが応答可能に

* **改善**
  * 移動パラメータを細かく設定可能に（距離・速度・継続時間・停止判定・ファントム）
  * ホーミング対象の追跡が安定化しターゲット追従が向上
  * エディタに攻撃プレビュー（インスペクタ／シーン表示）を追加し調整が容易に

* **修正**
  * 攻撃移動のキャンセル／完了処理を堅牢化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->