### PR TITLE
Playerのコンボアニメーション遷移を滑らかにできるように機能追加

### DIFF
--- a/Assets/Data/PlayerData/AttackData/ThunderChargeAttack.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderChargeAttack.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Thunder_Heavy_1
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/ThunderChargeAttack0.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderChargeAttack0.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Thunder_Heavy_1
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/ThunderChargeAttack2-1.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderChargeAttack2-1.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Thunder_Heavy_2
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/ThunderChargeAttack2.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderChargeAttack2.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Thunder_Heavy_1
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/ThunderCombo1.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderCombo1.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Thunder_Combo_1
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/ThunderCombo2.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderCombo2.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Thunder_Combo_2
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/ThunderCombo3.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderCombo3.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Thunder_Combo_3
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/ThunderCombo4.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderCombo4.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Thunder_Combo_4
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/ThunderDodgeAttack.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderDodgeAttack.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: 
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/WarriorChargeAttack.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorChargeAttack.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Warrior_Heavy_2
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/WarriorChargeAttack0.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorChargeAttack0.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Warrior_Heavy_1
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/WarriorChargeAttack2-1.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorChargeAttack2-1.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Warrior_Heavy_3-1
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/WarriorChargeAttack2.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorChargeAttack2.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Warrior_Heavy_3
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/WarriorCombo1.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorCombo1.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Warrior_Combo_1
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/WarriorCombo2.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorCombo2.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Warrior_Combo_2
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/WarriorCombo3.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorCombo3.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: Warrior_Combo_3
+  _animationStartTime: 0.1

--- a/Assets/Data/PlayerData/AttackData/WarriorDodgeAttack.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorDodgeAttack.asset
@@ -42,3 +42,5 @@ MonoBehaviour:
     _weakPointMultiplier: 2
     _breakOrKillMultiplier: 2
     _weakAndBreakOrKillMultiplier: 2.5
+  _animationStateName: WarriorDodgeAttack
+  _animationStartTime: 0.1

--- a/Assets/Scripts/Data/Player/AttackData.cs
+++ b/Assets/Scripts/Data/Player/AttackData.cs
@@ -35,7 +35,7 @@ public class AttackData : ScriptableObject
     public HitStopData HitStopData => _hitStopData;
 
     public string AnimationStateName => _animationStateName;
-    public float AnimationStartTime => _animationStartTime;
+    public float TransitionDuration => _transitionDuration;
 
     [Header("Basic Info")]
     [SerializeField] private int _attackId;
@@ -79,7 +79,7 @@ public class AttackData : ScriptableObject
 
     [Header("Animation")]
     [SerializeField] private string _animationStateName; // Animatorのステート名
-    [SerializeField] private float _animationStartTime = -1f; // アニメーションの開始時間（秒）
+    [SerializeField] private float _transitionDuration = -1f; // アニメーションの開始時間（秒）
 }
 
 // 攻撃の段階（チャージレベル）

--- a/Assets/Scripts/Data/Player/AttackData.cs
+++ b/Assets/Scripts/Data/Player/AttackData.cs
@@ -79,7 +79,7 @@ public class AttackData : ScriptableObject
 
     [Header("Animation")]
     [SerializeField] private string _animationStateName; // Animatorのステート名
-    [SerializeField] private float _transitionDuration = -1f; // アニメーションの開始時間（秒）
+    [SerializeField] private float _transitionDuration = -1f; // 遷移時間（秒）。-1の場合はデフォルト値(0.1f)を使用
 }
 
 // 攻撃の段階（チャージレベル）

--- a/Assets/Scripts/Data/Player/AttackData.cs
+++ b/Assets/Scripts/Data/Player/AttackData.cs
@@ -34,6 +34,9 @@ public class AttackData : ScriptableObject
 
     public HitStopData HitStopData => _hitStopData;
 
+    public string AnimationStateName => _animationStateName;
+    public float AnimationStartTime => _animationStartTime;
+
     [Header("Basic Info")]
     [SerializeField] private int _attackId;
     [SerializeField] private string _attackName;
@@ -73,6 +76,10 @@ public class AttackData : ScriptableObject
 
     [Header("Hit Stop")]
     [SerializeField] private HitStopData _hitStopData;
+
+    [Header("Animation")]
+    [SerializeField] private string _animationStateName; // Animatorのステート名
+    [SerializeField] private float _animationStartTime = -1f; // アニメーションの開始時間（秒）
 }
 
 // 攻撃の段階（チャージレベル）

--- a/Assets/Scripts/Data/Player/AttackEventSMB.cs
+++ b/Assets/Scripts/Data/Player/AttackEventSMB.cs
@@ -16,8 +16,7 @@ public class AttackEventSMB : StateMachineBehaviour
     public override void OnStateUpdate(
     Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-        if (animator.speed == 0f) { return; } // アニメーションが停止している場合は処理しない
-
+        if (animator.speed == 0f) { return; }
         if (_controller == null) { return; }
 
         float currentTime = stateInfo.normalizedTime * stateInfo.length;
@@ -38,6 +37,9 @@ public class AttackEventSMB : StateMachineBehaviour
         {
             _comboEnded = true;
             _controller.AnimEvent_ComboWindowEnd();
+
+            // バッファがあれば即コンボ遷移
+            _controller.AnimEvent_ComboTransition();
         }
     }
 

--- a/Assets/Scripts/Interface/IAnimationController.cs
+++ b/Assets/Scripts/Interface/IAnimationController.cs
@@ -6,6 +6,7 @@ public interface IAnimationController
     public void AnimEvent_AttackComplete();
     public void AnimEvent_ComboWindowStart();
     public void AnimEvent_ComboWindowEnd();
+    public void AnimEvent_ComboTransition();
 }
 
 public interface IModeChangeAnimationController

--- a/Assets/Scripts/Player/PlayerAnimationController.cs
+++ b/Assets/Scripts/Player/PlayerAnimationController.cs
@@ -17,6 +17,7 @@ public class PlayerAnimationController : MonoBehaviour, IAnimationController, IM
     public event Action OnComboWindowEnd;
     public event Action OnAttackExecute;
     public event Action OnModeChangeComplete;
+    public event Action OnComboTransition;
 
     // アニメーションから呼ばれる関数
     public void AnimEvent_AttackExecute()
@@ -42,6 +43,11 @@ public class PlayerAnimationController : MonoBehaviour, IAnimationController, IM
     public void AnimEvent_ModeChangeComplete()
     {
         OnModeChangeComplete?.Invoke();
+    }
+
+    public void AnimEvent_ComboTransition()
+    {
+        OnComboTransition?.Invoke();
     }
 
     public void UpdateMoveAnimation(float speed)
@@ -86,6 +92,23 @@ public class PlayerAnimationController : MonoBehaviour, IAnimationController, IM
         }
 
         _animator.speed = _beforeAnimSpeed * speed;
+    }
+
+    public void PlayAttackBlend(int attackId, string stateName, float transitionDuration = 0.1f)
+    {
+        _animator.SetInteger(AnimParams.AttackId, attackId);
+
+        if (!string.IsNullOrEmpty(stateName))
+        {
+            // 現在のステートからブレンドしながら直接遷移
+            // 第3引数 = レイヤーインデックス（0 = Base Layer）
+            _animator.CrossFadeInFixedTime(stateName, transitionDuration, 0);
+        }
+        else
+        {
+            // フォールバック：従来通り
+            _animator.SetTrigger(AnimParams.Attack);
+        }
     }
 
     public void OnDestroy()

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -376,10 +376,20 @@ public class PlayerAttack : MonoBehaviour
 
         _stateManager.ChangeState(PlayerState.Attacking);
 
+        if (nextAttack.TransitionDuration < 0)
+        {
+            // 遷移時間が負の場合はデフォルトの遷移時間を使用
+            _animationController.PlayAttackBlend(
+                _currentAttackId,
+                nextAttack.AnimationStateName
+            );
+            return;
+        }
+
         _animationController.PlayAttackBlend(
             _currentAttackId,
             nextAttack.AnimationStateName,
-            nextAttack.AnimationStartTime
+            nextAttack.TransitionDuration
         );
     }
 

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -1,4 +1,3 @@
-using Cysharp.Threading.Tasks;
 using System;
 using System.Linq;
 using UnityEngine;
@@ -373,6 +372,36 @@ public class PlayerAttack : MonoBehaviour
         _pendingAttackData = nextAttack;
         _pendingAttackInput = bufferedInput;
         _lastAttackTime = Time.time;
+
+        // PrepareAttack と同等の副作用を適用
+        if (nextAttack.EnableHoming)
+        {
+            _isHomingActive = true;
+            _homingRadius = nextAttack.HomingRadius;
+            _homingAngle = nextAttack.HomingAngle;
+            _homingStrength = nextAttack.HomingStrength;
+            _homingTarget = FindHomingTarget(_homingRadius, _homingAngle);
+        }
+        else
+        {
+            _homingTarget = null;
+        }
+
+        if (nextAttack.MoveType != AttackMoveType.None)
+        {
+            var moveRequest = new AttackMoveRequest
+            {
+                MoveType = nextAttack.MoveType,
+                Distance = nextAttack.MoveDistance,
+                Speed = nextAttack.MoveSpeed,
+                Duration = nextAttack.MoveDuration,
+                Target = _homingTarget,
+                StopDistance = nextAttack.StopOnHit ? nextAttack.AttackRange : 0,
+                IsPhantom = nextAttack.IsPhantom
+            }
+                 ;
+            OnAttackMoveRequested?.Invoke(moveRequest);
+        }
 
         _stateManager.ChangeState(PlayerState.Attacking);
 

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -398,8 +398,8 @@ public class PlayerAttack : MonoBehaviour
                 Target = _homingTarget,
                 StopDistance = nextAttack.StopOnHit ? nextAttack.AttackRange : 0,
                 IsPhantom = nextAttack.IsPhantom
-            }
-                 ;
+            };
+
             OnAttackMoveRequested?.Invoke(moveRequest);
         }
 

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -36,6 +36,7 @@ public class PlayerAttack : MonoBehaviour
         _animationController.OnAttackComplete += FinishAttack;
         _animationController.OnComboWindowStart += OnComboWindowStart;
         _animationController.OnComboWindowEnd += OnComboWindowEnd;
+        _animationController.OnComboTransition += TryComboTransition;
 
         // 設定に応じて登録するイベントを変更
         switch (_dodgeAttackConfig.DodgeAttackType)
@@ -98,6 +99,7 @@ public class PlayerAttack : MonoBehaviour
     private float _chargeStartTime = -999f;
     private bool _hasBufferedDodgeAttack = false;
     private bool _isInComboWindow = false;
+    private bool _isComboTransitioned = false;
 
     private bool _isHomingActive;
     private float _homingStrength;
@@ -148,6 +150,7 @@ public class PlayerAttack : MonoBehaviour
             _animationController.OnAttackComplete -= FinishAttack;
             _animationController.OnComboWindowStart -= OnComboWindowStart;
             _animationController.OnComboWindowEnd -= OnComboWindowEnd;
+            _animationController.OnComboTransition -= TryComboTransition;
         }
     }
 
@@ -328,7 +331,7 @@ public class PlayerAttack : MonoBehaviour
         }
 
         // アニメーション再生のみ
-        _animationController.PlayAttack(_currentAttackId);
+        _animationController.PlayAttackBlend(_currentAttackId, attackData.AnimationStateName);
     }
 
     /// <summary>
@@ -351,28 +354,61 @@ public class PlayerAttack : MonoBehaviour
     }
 
     /// <summary>
+    /// コンボウィンドウ開始時点でバッファがあれば、
+    /// ステートが生きているうちにCrossFadeで遷移
+    /// </summary>
+    private void TryComboTransition()
+    {
+        if (!_bufferedComboInput.HasValue) { return; }
+
+        var bufferedInput = _bufferedComboInput.Value;
+        _bufferedComboInput = null;
+
+        AttackData nextAttack = GetNextAttack(bufferedInput, allowCombo: true);
+        if (nextAttack == null) { return; }
+
+        _isComboTransitioned = true; // 追加
+
+        _currentAttackId = nextAttack.AttackId;
+        _pendingAttackData = nextAttack;
+        _pendingAttackInput = bufferedInput;
+        _lastAttackTime = Time.time;
+
+        _stateManager.ChangeState(PlayerState.Attacking);
+
+        _animationController.PlayAttackBlend(
+            _currentAttackId,
+            nextAttack.AnimationStateName,
+            nextAttack.AnimationStartTime
+        );
+    }
+
+    /// <summary>
     /// アニメーションイベントから呼ばれる攻撃終了関数
     /// </summary>
     private void FinishAttack()
     {
         _isHomingActive = false;
 
-        _stateManager.ChangeState(PlayerState.Idle);
+        // コンボ遷移済みの場合はpendingをクリアしない
+        if (_isComboTransitioned)
+        {
+            _isComboTransitioned = false;
+            return; // 次のステートに引き継ぐ
+        }
+
         _pendingAttackData = null;
         _pendingAttackInput = null;
 
-        // バッファされたコンボ入力があれば実行
         if (_bufferedComboInput.HasValue)
         {
             var bufferedInput = _bufferedComboInput.Value;
             _bufferedComboInput = null;
-
-            Debug.Log($"バッファされたコンボを実行: {bufferedInput.AttackType}");
-            PrepareAttack(bufferedInput, true);
+            PrepareAttack(bufferedInput, allowCombo: true);
         }
         else
         {
-            // コンボが途切れた
+            _stateManager.ChangeState(PlayerState.Idle);
             ResetCombo();
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * コンボ遷移が強化され、コンボウィンドウ中に入力をバッファして即座に遷移できるようになり、連続攻撃がより滑らかになりました。
  * 攻撃アニメーションに状態名と遷移時間の設定オプションが追加され、ブレンド再生によりより自然なアニメーション切替が可能になりました。
  * コンボ遷移時の状態維持と入力処理が改善され、次攻撃への継続が安定しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->