### PR TITLE
パラメーター進化時のエフェクト再生

### DIFF
--- a/Assets/Data/SkillData/GroundCrushSkill 1.asset
+++ b/Assets/Data/SkillData/GroundCrushSkill 1.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   _explanation: "\u30B3\u30F3\u30DC\u306E\u6700\u5F8C\u306E\u4E00\u6483\u306E\u5A01\u529B\u304C20\uFF05\u30A2\u30C3\u30D7\u3057\u3001\u3055\u3089\u306B\u7BC4\u56F2\u653B\u6483\u304C\u4ED8\u4E0E\u3055\u308C\u308B\u3002"
   _icon: {fileID: 0}
   _timing: 0
-  _evolutionSkill: {fileID: 11400000, guid: 558a011b8cb78cd4eab0e3c8484f5066, type: 2}
+  _unlockedSkill: {fileID: 11400000, guid: 558a011b8cb78cd4eab0e3c8484f5066, type: 2}
   _defaultUnlocked: 1
   _boostAmount: 0.2
   _requiredComboIndex: 2

--- a/Assets/Data/SkillData/GroundCrushSkill 2.asset
+++ b/Assets/Data/SkillData/GroundCrushSkill 2.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   _explanation: "\u30B3\u30F3\u30DC\u6700\u5F8C\u306E\u4E00\u6483\u306E\u5F8C\u3001\u524D\u65B9\u306B\u30C7\u30A3\u30EC\u30A4\u306E\u304B\u304B\u3063\u305F\u4E38\u5F62\u306E\u885D\u6CE2\u6CE2\u304C\u767A\u751F"
   _icon: {fileID: 0}
   _timing: 0
-  _evolutionSkill: {fileID: 11400000, guid: 892c393506ae311438bd3c9311763873, type: 2}
+  _unlockedSkill: {fileID: 11400000, guid: 892c393506ae311438bd3c9311763873, type: 2}
   _defaultUnlocked: 0
   _getComboCount: 2
   _attackRadius: 2.5

--- a/Assets/Data/SkillData/LightningStrike 1.asset
+++ b/Assets/Data/SkillData/LightningStrike 1.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   _explanation: 
   _icon: {fileID: 0}
   _timing: 2
-  _evolutionSkill: {fileID: 11400000, guid: a05c65a211dbe2d498e4beba93a2dae0, type: 2}
+  _unlockedSkill: {fileID: 11400000, guid: a05c65a211dbe2d498e4beba93a2dae0, type: 2}
   _defaultUnlocked: 1
   _targetCount: 1
   _minInterval: 2

--- a/Assets/Data/SkillData/LightningStrike 2.asset
+++ b/Assets/Data/SkillData/LightningStrike 2.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   _explanation: 
   _icon: {fileID: 0}
   _timing: 2
-  _evolutionSkill: {fileID: 11400000, guid: 53722a74beee9cd4e82e6941a3cd16e7, type: 2}
+  _unlockedSkill: {fileID: 11400000, guid: 53722a74beee9cd4e82e6941a3cd16e7, type: 2}
   _defaultUnlocked: 0
   _targetCount: 2
   _minInterval: 2

--- a/Assets/Prefab/Effect/Level Up Blue VFX.prefab
+++ b/Assets/Prefab/Effect/Level Up Blue VFX.prefab
@@ -1,0 +1,626 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5903032592519319049
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5903032592519319040}
+  - component: {fileID: 5903032592519319047}
+  - component: {fileID: 5903032592519319046}
+  - component: {fileID: 5903032592519319045}
+  - component: {fileID: 5903032592519319051}
+  - component: {fileID: 5903032592519319050}
+  - component: {fileID: 5903032592519319048}
+  m_Layer: 0
+  m_Name: Level Up Blue VFX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5903032592519319040
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5903032592519319049}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!2083052967 &5903032592519319047
+VisualEffect:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5903032592519319049}
+  m_Enabled: 1
+  m_Asset: {fileID: 8926484042661614526, guid: 5b633feab5c77504ba87c91669e7d2bf, type: 3}
+  m_InitialEventName: hit
+  m_InitialEventNameOverriden: 1
+  m_StartSeed: 0
+  m_ResetSeedOnPlay: 1
+  m_AllowInstancing: 1
+  m_ResourceVersion: 1
+  m_PropertySheet:
+    m_Float:
+      m_Array:
+      - m_Value: 1.8
+        m_Name: VFXHeight
+        m_Overridden: 1
+      - m_Value: 768
+        m_Name: SwarmSpawnRate
+        m_Overridden: 0
+      - m_Value: 1.1
+        m_Name: SwarmLifetimeMax
+        m_Overridden: 0
+      - m_Value: 0.35
+        m_Name: EyeGlowSize
+        m_Overridden: 0
+      - m_Value: 1.5
+        m_Name: SwarmDraughtMultiplier
+        m_Overridden: 0
+      - m_Value: 3
+        m_Name: SwarmGravityY
+        m_Overridden: 1
+      - m_Value: 32
+        m_Name: FervorSpawnRate
+        m_Overridden: 0
+      - m_Value: 128
+        m_Name: CreateSpikesSpawnCount
+        m_Overridden: 0
+      - m_Value: 0.5
+        m_Name: CreateSpikesLifetimeMax
+        m_Overridden: 0
+      - m_Value: 48
+        m_Name: CreateColumnSpawnCount
+        m_Overridden: 0
+      - m_Value: 0.25
+        m_Name: CreateColumnWidth
+        m_Overridden: 0
+      - m_Value: 0.8
+        m_Name: CreateColumnLifetimeMax
+        m_Overridden: 0
+      - m_Value: 8
+        m_Name: CreateWavesSpawnCount
+        m_Overridden: 0
+      - m_Value: 1.2
+        m_Name: FervorLifetimeMax
+        m_Overridden: 0
+      - m_Value: 64
+        m_Name: EndSpikesSpawnCount
+        m_Overridden: 0
+      - m_Value: 0.65
+        m_Name: EndGlowAlphaMax
+        m_Overridden: 0
+      - m_Value: 1.25
+        m_Name: EndGlowLifetimeMax
+        m_Overridden: 0
+      - m_Value: 0.5
+        m_Name: EndCircleAlpha
+        m_Overridden: 0
+      - m_Value: 64
+        m_Name: CoreSpawnRate
+        m_Overridden: 0
+      - m_Value: 384
+        m_Name: SmokeSpawnRate
+        m_Overridden: 0
+      - m_Value: 24
+        m_Name: RaysSpawnRate
+        m_Overridden: 0
+      - m_Value: 1
+        m_Name: CreateShockwaveAlpha
+        m_Overridden: 0
+      - m_Value: 48
+        m_Name: CreateRaysSpawnCount
+        m_Overridden: 0
+      - m_Value: 1.2
+        m_Name: CreateSmokeLifetimeMax
+        m_Overridden: 0
+      - m_Value: 96
+        m_Name: CreateSmokeSpawnCount
+        m_Overridden: 0
+      - m_Value: 640
+        m_Name: EndSwarmSpawnCount
+        m_Overridden: 0
+      - m_Value: 6
+        m_Name: EndShockwaveSpawnCount
+        m_Overridden: 0
+      - m_Value: 0.9
+        m_Name: EndSwarmLifetimeMax
+        m_Overridden: 0
+      - m_Value: 0.5
+        m_Name: SymbolSize
+        m_Overridden: 0
+      - m_Value: 1.9
+        m_Name: SymbolYOffsetFromGround
+        m_Overridden: 0
+      - m_Value: 1
+        m_Name: SymbolAlpha
+        m_Overridden: 1
+      - m_Value: 1.75
+        m_Name: SymbolLifetime
+        m_Overridden: 1
+      - m_Value: 1.5
+        m_Name: CritBoltsSmallSpawnDuration
+        m_Overridden: 1
+      - m_Value: 384
+        m_Name: SwarmSpawnCount
+        m_Overridden: 1
+      - m_Value: 8
+        m_Name: SpiralSpawnCount
+        m_Overridden: 1
+      - m_Value: 1.6
+        m_Name: RingSize
+        m_Overridden: 1
+      - m_Value: 96
+        m_Name: SparksSpawnCount
+        m_Overridden: 1
+      - m_Value: 8
+        m_Name: StripsSpawnCount
+        m_Overridden: 1
+      - m_Value: 1.2
+        m_Name: StripsSpawnRadius
+        m_Overridden: 1
+      - m_Value: 8
+        m_Name: CritBoltsLargeSpawnCount
+        m_Overridden: 1
+      - m_Value: 12
+        m_Name: CritBoltsSmallSpawnRate
+        m_Overridden: 1
+      - m_Value: 24
+        m_Name: CritWaveSpawnCount
+        m_Overridden: 1
+      - m_Value: 0.4
+        m_Name: CritWaveSpawnWidth
+        m_Overridden: 1
+    m_Vector2f:
+      m_Array:
+      - m_Value: {x: 0.4, y: 0.6}
+        m_Name: SwarmSizeMinMax
+        m_Overridden: 1
+      - m_Value: {x: 0.04, y: 0.08}
+        m_Name: EyeBeamWidthMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.06, y: 0.14}
+        m_Name: FervorAlphaMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.5, y: 0.8}
+        m_Name: FervorSizeMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.15, y: 0.3}
+        m_Name: CreateSpikesSizeMinMax
+        m_Overridden: 0
+      - m_Value: {x: 4, y: 9}
+        m_Name: CreateSpikesGravityMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.2, y: 0.8}
+        m_Name: CreateColumnAlphaMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.5, y: 0.8}
+        m_Name: CreateColumnSizeMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.2, y: 0.5}
+        m_Name: CreateWavesLifetimeMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.3, y: 1.5}
+        m_Name: CreateWavesSizeMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.1, y: 1}
+        m_Name: CreateWavesAlphaMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.15, y: 0.25}
+        m_Name: EndSpikesSizeMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.3, y: 0.6}
+        m_Name: EndSpikesAlphaMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.02, y: 0.04}
+        m_Name: SwarmAlphaMinMax
+        m_Overridden: 1
+      - m_Value: {x: 0.75, y: 1}
+        m_Name: CoreAlphaMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.5, y: 1}
+        m_Name: SmokeAlphaMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.4, y: 0.8}
+        m_Name: CoreLifetimeMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.75, y: 1.25}
+        m_Name: CoreSizeMinMax
+        m_Overridden: 0
+      - m_Value: {x: 1, y: 1.5}
+        m_Name: SmokeSizeMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.05, y: 0.1}
+        m_Name: RaysAlphaMinMax
+        m_Overridden: 0
+      - m_Value: {x: 1, y: 2}
+        m_Name: RaysSizeMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.5, y: 1}
+        m_Name: CreateRaysAlphaMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.5, y: 1}
+        m_Name: CreateSmokeAlphaMinMax
+        m_Overridden: 0
+      - m_Value: {x: 1, y: 1.5}
+        m_Name: CreateSmokeSizeMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.08, y: 0.22}
+        m_Name: EndSwarmSizeMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.05, y: 0.5}
+        m_Name: EndSwarmAlphaMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.08, y: 0.18}
+        m_Name: EndShockwaveAlphaMinMax
+        m_Overridden: 0
+      - m_Value: {x: 0.4, y: 0.6}
+        m_Name: SwarmLifetimeMinMax
+        m_Overridden: 1
+      - m_Value: {x: 0.5, y: 0.6}
+        m_Name: SpiralSizeMinMax
+        m_Overridden: 1
+      - m_Value: {x: 1, y: 1.2}
+        m_Name: BarsSizeMinMax
+        m_Overridden: 1
+      - m_Value: {x: 0.1, y: 0.5}
+        m_Name: SpiralAlphaMinMax
+        m_Overridden: 1
+      - m_Value: {x: 0.75, y: 1}
+        m_Name: BarsAlphaMinMax
+        m_Overridden: 1
+      - m_Value: {x: 0.4, y: 0.6}
+        m_Name: SparksSizeMinMax
+        m_Overridden: 1
+      - m_Value: {x: 0.1, y: 1}
+        m_Name: SparksAlphaMinMax
+        m_Overridden: 1
+      - m_Value: {x: 0.075, y: 0.1}
+        m_Name: StripsSizeMinMax
+        m_Overridden: 1
+      - m_Value: {x: 0.1, y: 0.2}
+        m_Name: StripsAlphaMinMax
+        m_Overridden: 1
+      - m_Value: {x: 0.2, y: 0.35}
+        m_Name: CritBoltsSmallSizeMinMax
+        m_Overridden: 1
+      - m_Value: {x: 0.1, y: 1}
+        m_Name: CritWaveAlphaMinMax
+        m_Overridden: 1
+      - m_Value: {x: 0.4, y: 0.6}
+        m_Name: CritWaveSizeMinMax
+        m_Overridden: 1
+    m_Vector3f:
+      m_Array:
+      - m_Value: {x: 356.61206, y: 0, z: 270}
+        m_Name: VFXTransform_angles
+        m_Overridden: 1
+      - m_Value: {x: -1.7617678e-17, y: 1.0314258, z: 0.042659335}
+        m_Name: VFXTransform_position
+        m_Overridden: 1
+      - m_Value: {x: 1, y: 1, z: 1}
+        m_Name: VFXTransform_scale
+        m_Overridden: 1
+      - m_Value: {x: 7.0000005, y: -0.000000645139, z: 270}
+        m_Name: SkinnedMeshTransform_angles
+        m_Overridden: 1
+      - m_Value: {x: 1.1979284e-33, y: 0.8400196, z: 0.027500711}
+        m_Name: SkinnedMeshTransform_position
+        m_Overridden: 1
+      - m_Value: {x: 1, y: 1.000021, z: 1.0000209}
+        m_Name: SkinnedMeshTransform_scale
+        m_Overridden: 1
+      - m_Value: {x: 0, y: 0.1, z: 0}
+        m_Name: VFXCenterOffset
+        m_Overridden: 1
+      - m_Value: {x: -0.000000603709, y: 0, z: 270}
+        m_Name: LeftEyeTransform_angles
+        m_Overridden: 1
+      - m_Value: {x: 6.3102135e-17, y: 1.4188018, z: -0.0022168104}
+        m_Name: LeftEyeTransform_position
+        m_Overridden: 1
+      - m_Value: {x: 1, y: 1, z: 1}
+        m_Name: LeftEyeTransform_scale
+        m_Overridden: 1
+      - m_Value: {x: -0.000000603709, y: 0, z: 270}
+        m_Name: RightEyeTransform_angles
+        m_Overridden: 1
+      - m_Value: {x: 0.040001586, y: 1.5107601, z: 0.07351604}
+        m_Name: RightEyeTransform_position
+        m_Overridden: 1
+      - m_Value: {x: 1, y: 1, z: 1}
+        m_Name: RightEyeTransform_scale
+        m_Overridden: 1
+      - m_Value: {x: -0.088, y: -0.041, z: 0.12}
+        m_Name: LeftEyeOffset
+        m_Overridden: 0
+      - m_Value: {x: 0, y: 0, z: 0}
+        m_Name: HeadTransform_angles
+        m_Overridden: 0
+      - m_Value: {x: 0, y: 0, z: 0}
+        m_Name: HeadTransform_position
+        m_Overridden: 0
+      - m_Value: {x: 1, y: 1, z: 1}
+        m_Name: HeadTransform_scale
+        m_Overridden: 0
+      - m_Value: {x: 356.61206, y: 0, z: 270}
+        m_Name: VFXCenterTransform_angles
+        m_Overridden: 1
+      - m_Value: {x: -1.7617678e-17, y: 1.0314258, z: 0.042659335}
+        m_Name: VFXCenterTransform_position
+        m_Overridden: 1
+      - m_Value: {x: 1, y: 1, z: 1}
+        m_Name: VFXCenterTransform_scale
+        m_Overridden: 1
+      - m_Value: {x: -0, y: 0, z: 0}
+        m_Name: VFXRotation_angles
+        m_Overridden: 1
+      - m_Value: {x: 0, y: 0, z: 0}
+        m_Name: VFXRotation_position
+        m_Overridden: 1
+      - m_Value: {x: 1, y: 1, z: 1}
+        m_Name: VFXRotation_scale
+        m_Overridden: 1
+      - m_Value: {x: 0, y: 0, z: 90}
+        m_Name: VFXRotationOffset
+        m_Overridden: 1
+      - m_Value: {x: 0, y: 0.2, z: 0}
+        m_Name: VFXOffset
+        m_Overridden: 1
+      - m_Value: {x: -0.12, y: 0.19, z: 0.16}
+        m_Name: RightEyeBeamEndOffset
+        m_Overridden: 0
+      - m_Value: {x: -0.12, y: -0.19, z: 0.16}
+        m_Name: LeftEyeBeamEndOffset
+        m_Overridden: 0
+      - m_Value: {x: -0, y: 0, z: 0}
+        m_Name: GroundParentTransform_angles
+        m_Overridden: 1
+      - m_Value: {x: 0, y: 0, z: 0}
+        m_Name: GroundParentTransform_position
+        m_Overridden: 1
+      - m_Value: {x: 1, y: 1, z: 1}
+        m_Name: GroundParentTransform_scale
+        m_Overridden: 1
+    m_Vector4f:
+      m_Array:
+      - m_Value: {x: 1.9521693, y: 1.2422895, z: 33.89676, w: 1}
+        m_Name: SecondaryColor
+        m_Overridden: 1
+    m_Uint:
+      m_Array: []
+    m_Int:
+      m_Array: []
+    m_Matrix4x4f:
+      m_Array: []
+    m_AnimationCurve:
+      m_Array: []
+    m_Gradient:
+      m_Array:
+      - m_Value:
+          serializedVersion: 2
+          key0: {r: 0.627451, g: 11.984314, b: 11.984314, a: 1}
+          key1: {r: 1.6558532, g: 4.9675593, b: 31.626795, a: 1}
+          key2: {r: 0.627451, g: 1.882353, b: 11.984314, a: 0}
+          key3: {r: 0.17951572, g: 0.575328, b: 3.4854097, a: 0}
+          key4: {r: 0.035733357, g: 0.14336184, b: 0.6886792, a: 0}
+          key5: {r: 0, g: 0, b: 0, a: 0}
+          key6: {r: 0, g: 0, b: 0, a: 0}
+          key7: {r: 0, g: 0, b: 0, a: 0}
+          ctime0: 188
+          ctime1: 22937
+          ctime2: 39321
+          ctime3: 52428
+          ctime4: 65535
+          ctime5: 0
+          ctime6: 0
+          ctime7: 0
+          atime0: 0
+          atime1: 65535
+          atime2: 0
+          atime3: 0
+          atime4: 0
+          atime5: 0
+          atime6: 0
+          atime7: 0
+          m_Mode: 0
+          m_ColorSpace: -1
+          m_NumColorKeys: 5
+          m_NumAlphaKeys: 2
+        m_Name: ColorOverLife
+        m_Overridden: 1
+      - m_Value:
+          serializedVersion: 2
+          key0: {r: 5.2164755, g: 3.2500553, b: 0.2731139, a: 1}
+          key1: {r: 6.0084367, g: 3.8156726, b: 0.46142435, a: 1}
+          key2: {r: 11.984314, g: 8.083635, b: 1.8823531, a: 0}
+          key3: {r: 1.5529412, g: 1.2707176, b: 0.97566986, a: 0}
+          key4: {r: 0.7490196, g: 0.6431373, b: 0.47058824, a: 0}
+          key5: {r: 0, g: 0, b: 0, a: 0}
+          key6: {r: 0, g: 0, b: 0, a: 0}
+          key7: {r: 0, g: 0, b: 0, a: 0}
+          ctime0: 0
+          ctime1: 9830
+          ctime2: 18013
+          ctime3: 43882
+          ctime4: 65535
+          ctime5: 0
+          ctime6: 0
+          ctime7: 0
+          atime0: 0
+          atime1: 65535
+          atime2: 0
+          atime3: 0
+          atime4: 0
+          atime5: 0
+          atime6: 0
+          atime7: 0
+          m_Mode: 0
+          m_ColorSpace: -1
+          m_NumColorKeys: 5
+          m_NumAlphaKeys: 2
+        m_Name: ColorOverLife 1
+        m_Overridden: 1
+      - m_Value:
+          serializedVersion: 2
+          key0: {r: 5.2164755, g: 3.2500553, b: 0.2731139, a: 1}
+          key1: {r: 11.984314, g: 7.9686275, b: 1.882353, a: 1}
+          key2: {r: 1.5529412, g: 1.3254902, b: 0.972549, a: 0}
+          key3: {r: 0.7490196, g: 0.6431373, b: 0.47058824, a: 0}
+          key4: {r: 0, g: 0, b: 0, a: 0}
+          key5: {r: 0, g: 0, b: 0, a: 0}
+          key6: {r: 0, g: 0, b: 0, a: 0}
+          key7: {r: 0, g: 0, b: 0, a: 0}
+          ctime0: 0
+          ctime1: 18013
+          ctime2: 44265
+          ctime3: 65535
+          ctime4: 0
+          ctime5: 0
+          ctime6: 0
+          ctime7: 0
+          atime0: 0
+          atime1: 65535
+          atime2: 0
+          atime3: 0
+          atime4: 0
+          atime5: 0
+          atime6: 0
+          atime7: 0
+          m_Mode: 0
+          m_ColorSpace: -1
+          m_NumColorKeys: 4
+          m_NumAlphaKeys: 2
+        m_Name: SecondaryGradient
+        m_Overridden: 0
+    m_NamedObject:
+      m_Array:
+      - m_Value: {fileID: 0}
+        m_Name: SkinnedMesh
+        m_Overridden: 1
+      - m_Value: {fileID: 2800000, guid: 04f389ae0ac63ca4784402c348aa4521, type: 3}
+        m_Name: SymbolTexture
+        m_Overridden: 0
+    m_Bool:
+      m_Array: []
+--- !u!73398921 &5903032592519319046
+VFXRenderer:
+  serializedVersion: 1
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5903032592519319049}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+--- !u!114 &5903032592519319045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5903032592519319049}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cdafc37f32b176349b1684c4455b98e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExecuteInEditor: 1
+  m_Bindings:
+  - {fileID: 5903032592519319051}
+  - {fileID: 5903032592519319048}
+  m_VisualEffect: {fileID: 5903032592519319047}
+--- !u!114 &5903032592519319051
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5903032592519319049}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7fdfea1f838247c40921a07afedde962, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Space: 0
+  m_Property:
+    m_Name: SkinnedMeshTransform
+  Target: {fileID: 0}
+--- !u!114 &5903032592519319050
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5903032592519319049}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 50c780b64d7b0c941a7428ec7f33a80f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5903032592519319048
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5903032592519319049}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7fdfea1f838247c40921a07afedde962, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Space: 0
+  m_Property:
+    m_Name: GroundParentTransform
+  Target: {fileID: 0}

--- a/Assets/Prefab/Effect/Level Up Blue VFX.prefab.meta
+++ b/Assets/Prefab/Effect/Level Up Blue VFX.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 73101d84ac436ea4aaf3fe9407413629
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefab/System/Manager.prefab
+++ b/Assets/Prefab/System/Manager.prefab
@@ -394,6 +394,39 @@ MonoBehaviour:
   - {fileID: 11400000, guid: cdd70c5089849144796ad90dd35a5120, type: 2}
   - {fileID: 11400000, guid: 3336e1da02a5ba546bf36ed3dc4c8ce8, type: 2}
   - {fileID: 11400000, guid: 37ca213cabe23b34a9deb1fe862cd85f, type: 2}
+--- !u!1 &6838469318861114545
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 7526176138336370825, guid: f68705bb885c23b4da297313532cca84, type: 3}
+  m_PrefabInstance: {fileID: 3933127706942655544}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6838469318861114552}
+  - component: {fileID: 8704867766960650360}
+  m_Layer: 0
+  m_Name: 'Level Up Orange VFX (Missing Prefab with guid: f68705bb885c23b4da297313532cca84)'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6838469318861114552
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 7526176138336370816, guid: f68705bb885c23b4da297313532cca84, type: 3}
+  m_PrefabInstance: {fileID: 3933127706942655544}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6838469318861114545}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.29603958, y: -0.14262, z: -0.12065983}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 465168283181710735}
+  m_Father: {fileID: 1002532630286587311}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6966947227818494167
 GameObject:
   m_ObjectHideFlags: 0
@@ -587,7 +620,9 @@ Transform:
   m_LocalPosition: {x: -0.29603958, y: 0.14262, z: 0.12065983}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 6838469318861114552}
+  - {fileID: 527146034796436038}
   m_Father: {fileID: 7036861525032570302}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &411399310545014901
@@ -602,6 +637,553 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3e24f7325540d2d4588c7c0615cca46d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerEffectInitializer
-  _thunderEffect: {fileID: 0}
+  _thunderEffect: {fileID: 7912003911011555792}
   _thunderEffectView: {fileID: 0}
   _warriorEffectView: {fileID: 0}
+  _levelUpEffectView: {fileID: 8704867766960650360}
+--- !u!1001 &2347181242427078975
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1002532630286587311}
+    m_Modifications:
+    - target: {fileID: 2864870325628134256, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_Name
+      value: Energize Teal VFX
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.29603958
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.14262
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.12065983
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_InitialEventName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_InitialEventNameOverriden
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.x
+      value: 355.26205
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.y
+      value: 21.189276
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
+      value: 204.13531
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.x
+      value: -0.84651184
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.y
+      value: 1.2879226
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.z
+      value: 12.11333
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.x
+      value: 1.0000001
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.y
+      value: 1.0000002
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.z
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 2864870325628134256, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7912003911011555792}
+  m_SourcePrefab: {fileID: 100100000, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+--- !u!2083052967 &527146034796436033 stripped
+VisualEffect:
+  m_CorrespondingSourceObject: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+  m_PrefabInstance: {fileID: 2347181242427078975}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &527146034796436038 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+  m_PrefabInstance: {fileID: 2347181242427078975}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &527146034796436047 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2864870325628134256, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+  m_PrefabInstance: {fileID: 2347181242427078975}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7912003911011555792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 527146034796436047}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e49bac7b4f32234aaa19c8c9bea6221, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ThunderEffect
+  _vfx: {fileID: 527146034796436033}
+--- !u!1001 &3933127706942655544
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1002532630286587311}
+    m_Modifications:
+    - target: {fileID: 7526176138336370816, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.29603958
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370816, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.14262
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370816, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.12065983
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370816, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370816, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370816, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370816, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370816, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370816, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370816, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_InitialEventName
+      value: hit
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_InitialEventNameOverriden
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.x
+      value: 355.26205
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.y
+      value: 21.189276
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
+      value: 204.13531
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.x
+      value: -0.84651184
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.y
+      value: 1.2879226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.z
+      value: 12.11333
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.x
+      value: 1.0000001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.y
+      value: 1.0000002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Gradient.m_Array.Array.data[0].m_Overridden
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Vector4f.m_Array.Array.data[0].m_Overridden
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Gradient.m_Array.Array.data[0].m_Value.ctime0
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370823, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_PropertySheet.m_Gradient.m_Array.Array.data[0].m_Value.m_ColorSpace
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526176138336370825, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      propertyPath: m_Name
+      value: Level Up Orange VFX
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 7526176138336370816, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 465168283181710735}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7526176138336370825, guid: f68705bb885c23b4da297313532cca84, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8704867766960650360}
+  m_SourcePrefab: {fileID: 100100000, guid: f68705bb885c23b4da297313532cca84, type: 3}
+--- !u!114 &8704867766960650360
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6838469318861114545}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: badbec4b346340040af1ab8747066130, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::LevelUpEffectView
+  _vfx: {fileID: 465168283181710728}
+  _effectDataArray:
+  - _statSkillType: 0
+    _symbolTexture: {fileID: 2800000, guid: cb3208c267dda2546a5cdabcfc7d2172, type: 3}
+    _secondaryColor: {r: 2.5567203, g: 20.224806, b: 4.326269, a: 0}
+    _colorOverLife:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 0.94339156, g: 29.926897, b: 1.2098284, a: 1}
+      key2: {r: 0.29058677, g: 363.51016, b: 3.6295571, a: 0}
+      key3: {r: 0.25764707, g: 380.34235, b: 3.7516537, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 26291
+      ctime2: 45412
+      ctime3: 59753
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: -1
+      m_NumColorKeys: 4
+      m_NumAlphaKeys: 2
+  - _statSkillType: 1
+    _symbolTexture: {fileID: 2800000, guid: cb3208c267dda2546a5cdabcfc7d2172, type: 3}
+    _secondaryColor: {r: 18.943594, g: 3.68149, b: 3.68149, a: 0}
+    _colorOverLife:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1024, g: 0, b: 0, a: 1}
+      key2: {r: 770.0553, g: 0.2482353, b: 0.2482353, a: 0}
+      key3: {r: 770.0553, g: 0.2482353, b: 0.2482353, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 52814
+      ctime2: 64070
+      ctime3: 65535
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: -1
+      m_NumColorKeys: 4
+      m_NumAlphaKeys: 2
+  - _statSkillType: 2
+    _symbolTexture: {fileID: 2800000, guid: cb3208c267dda2546a5cdabcfc7d2172, type: 3}
+    _secondaryColor: {r: 3.6240733, g: 3.6068964, b: 19.309656, a: 0}
+    _colorOverLife:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 0.6731455, g: 4.8298388, b: 28.275522, a: 1}
+      key2: {r: 0, g: 12.7172575, b: 84.44851, a: 0}
+      key3: {r: 0, g: 12.7172575, b: 84.44851, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 29684
+      ctime2: 63453
+      ctime3: 65535
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: -1
+      m_NumColorKeys: 4
+      m_NumAlphaKeys: 2
+  - _statSkillType: 3
+    _symbolTexture: {fileID: 2800000, guid: cb3208c267dda2546a5cdabcfc7d2172, type: 3}
+    _secondaryColor: {r: 20.491104, g: 22.055103, b: 2.455189, a: 0}
+    _colorOverLife:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 28.032042, g: 29.622498, b: 0.6570041, a: 1}
+      key2: {r: 79.811554, g: 84.44851, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 33847
+      ctime2: 65535
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: -1
+      m_NumColorKeys: 3
+      m_NumAlphaKeys: 2
+  - _statSkillType: 4
+    _symbolTexture: {fileID: 2800000, guid: cb3208c267dda2546a5cdabcfc7d2172, type: 3}
+    _secondaryColor: {r: 3.8120277, g: 18.553757, b: 20.407835, a: 0}
+    _colorOverLife:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 0.5517234, g: 35.03328, b: 38.408012, a: 1}
+      key2: {r: 0, g: 76.92027, b: 84.44851, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 34772
+      ctime2: 64841
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: -1
+      m_NumColorKeys: 3
+      m_NumAlphaKeys: 2
+  _effectDuration: 1.5
+--- !u!1001 &6313858423812797327
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6838469318861114552}
+    m_Modifications:
+    - target: {fileID: 5903032592519319040, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319040, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319040, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319040, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319040, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319040, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319040, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319040, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319040, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319040, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319047, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_InitialEventNameOverriden
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319047, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.x
+      value: 355.26205
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319047, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.y
+      value: 21.189276
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319047, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
+      value: 204.13531
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319047, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.x
+      value: -0.84651184
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319047, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.y
+      value: 1.2879226
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319047, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.z
+      value: 12.11333
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319047, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.x
+      value: 1.0000001
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319047, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.y
+      value: 1.0000002
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319047, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319047, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_PropertySheet.m_NamedObject.m_Array.Array.data[1].m_Overridden
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5903032592519319049, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+      propertyPath: m_Name
+      value: Level Up Blue VFX
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+--- !u!2083052967 &465168283181710728 stripped
+VisualEffect:
+  m_CorrespondingSourceObject: {fileID: 5903032592519319047, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+  m_PrefabInstance: {fileID: 6313858423812797327}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &465168283181710735 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5903032592519319040, guid: 73101d84ac436ea4aaf3fe9407413629, type: 3}
+  m_PrefabInstance: {fileID: 6313858423812797327}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefab/System/Manager.prefab
+++ b/Assets/Prefab/System/Manager.prefab
@@ -1075,7 +1075,7 @@ MonoBehaviour:
       m_ColorSpace: -1
       m_NumColorKeys: 3
       m_NumAlphaKeys: 2
-  _effectDuration: 1.5
+  _effectDuration: 2
 --- !u!1001 &6313858423812797327
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/TestScenes/PlayerTestScene.unity
+++ b/Assets/Scenes/TestScenes/PlayerTestScene.unity
@@ -447,118 +447,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3460f808bb5b66d4d96df11e226681f7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::SkillUIManager
---- !u!1001 &306936801
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2864870325628134256, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_Name
-      value: Energize Teal VFX
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134258, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: Target
-      value: 
-      objectReference: {fileID: 1360799734}
-    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_InitialEventName
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_InitialEventNameOverriden
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.x
-      value: 355.26205
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.y
-      value: 21.189276
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
-      value: 204.13531
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.x
-      value: -0.84651184
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.y
-      value: 1.2879226
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.z
-      value: 12.11333
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.x
-      value: 1.0000001
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.y
-      value: 1.0000002
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      propertyPath: m_PropertySheet.m_NamedObject.m_Array.Array.data[0].m_Value
-      value: 
-      objectReference: {fileID: 412175520}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2864870325628134256, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1923807871}
-  m_SourcePrefab: {fileID: 100100000, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
 --- !u!1001 &386668023
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1914,29 +1802,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 746240223}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1923807864 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2864870325628134256, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-  m_PrefabInstance: {fileID: 306936801}
-  m_PrefabAsset: {fileID: 0}
---- !u!2083052967 &1923807870 stripped
-VisualEffect:
-  m_CorrespondingSourceObject: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
-  m_PrefabInstance: {fileID: 306936801}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1923807871
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1923807864}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e49bac7b4f32234aaa19c8c9bea6221, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::ThunderEffect
-  _vfx: {fileID: 1923807870}
 --- !u!114 &1997347486 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8909495184104594486, guid: 5af8ef2a9aba5384abf2bdb272c10dff, type: 3}
@@ -3424,10 +3289,6 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 411399310545014901, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _thunderEffect
-      value: 
-      objectReference: {fileID: 1923807871}
-    - target: {fileID: 411399310545014901, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: _thunderEffectView
       value: 
       objectReference: {fileID: 6767515062201692496}
@@ -3435,6 +3296,22 @@ PrefabInstance:
       propertyPath: _warriorEffectView
       value: 
       objectReference: {fileID: 1054505149}
+    - target: {fileID: 465168283181710724, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 1360799734}
+    - target: {fileID: 465168283181710727, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 1298887711}
+    - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
+      propertyPath: m_PropertySheet.m_NamedObject.m_Array.Array.data[0].m_Value
+      value: 
+      objectReference: {fileID: 412175520}
+    - target: {fileID: 527146034796436045, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
+      propertyPath: Target
+      value: 
+      objectReference: {fileID: 1360799734}
     - target: {fileID: 3913965231841061834, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_Name
       value: Manager
@@ -3699,5 +3576,4 @@ SceneRoots:
   - {fileID: 6837170418680516860}
   - {fileID: 1099414539}
   - {fileID: 1617911759}
-  - {fileID: 306936801}
   - {fileID: 386668023}

--- a/Assets/Scenes/TestScenes/PlayerTestScene.unity
+++ b/Assets/Scenes/TestScenes/PlayerTestScene.unity
@@ -3396,6 +3396,10 @@ PrefabInstance:
       propertyPath: _normalCamera
       value: 
       objectReference: {fileID: 269304734}
+    - target: {fileID: 8704867766960650360, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
+      propertyPath: _effectDuration
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 9128100736884302578, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: _skillUIManager
       value: 

--- a/Assets/Scripts/Effect/LevelUp.meta
+++ b/Assets/Scripts/Effect/LevelUp.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fd47e826274c8ac438a507ecfef8e394
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Effect/LevelUp/LevelUpEffectPresenter.cs
+++ b/Assets/Scripts/Effect/LevelUp/LevelUpEffectPresenter.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+public class LevelUpEffectPresenter
+{
+    public LevelUpEffectPresenter(LevelUpEffectView view, SkillManager skillManager)
+    {
+        _view = view;
+        _skillManager = skillManager;
+
+        _skillManager.OnApply += Play;
+    }
+
+    public void Play(StatSkillType statType)
+    {
+        _view.Play(statType);
+    }
+
+    public void Dispose()
+    {
+        _skillManager.OnApply -= Play;
+    }
+
+    private readonly LevelUpEffectView _view;
+    private readonly SkillManager _skillManager;
+}

--- a/Assets/Scripts/Effect/LevelUp/LevelUpEffectPresenter.cs.meta
+++ b/Assets/Scripts/Effect/LevelUp/LevelUpEffectPresenter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e9bb26df0696f70428b593fb6bfcb2d1

--- a/Assets/Scripts/Effect/LevelUp/LevelUpEffectView.cs
+++ b/Assets/Scripts/Effect/LevelUp/LevelUpEffectView.cs
@@ -1,6 +1,5 @@
 using Cysharp.Threading.Tasks;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.VFX;
@@ -9,6 +8,9 @@ public class LevelUpEffectView : MonoBehaviour, ISpeedChange
 {
     public float TimeScale { get; set; } = 1f;
 
+    /// <summary>
+    /// プレイヤーのステータスアップに応じたエフェクトを再生する
+    /// </summary>
     public void Play(StatSkillType statType)
     {
         _effectQueue.Enqueue(statType);
@@ -69,8 +71,19 @@ public class LevelUpEffectView : MonoBehaviour, ISpeedChange
         {
             _effectMap[data.StatSkillType] = data;
         }
+
+        if (ServiceLocator.TryGet(out HitStopManager hitStopManager))
+        {
+            // プレイヤーにくっついているエフェクトなので、両方のグループに登録しておく
+            hitStopManager.Register(this, HitStopTargetGroup.Effects);
+            hitStopManager.Register(this, HitStopTargetGroup.Player);
+        }
     }
 
+    /// <summary>
+    /// エフェクトの再生をキューで管理する。複数のステータスアップが同時に発生した場合でも、順番にエフェクトを再生できるようにするため。
+    /// </summary>
+    /// <returns></returns>
     private async UniTask ProcessQueue()
     {
         while (_effectQueue.Count > 0)
@@ -87,6 +100,10 @@ public class LevelUpEffectView : MonoBehaviour, ISpeedChange
         _isPlaying = false;
     }
 
+    /// <summary>
+    /// 実際にエフェクトを再生する処理。StatSkillTypeに応じて、VFXのパラメータを設定してから再生する。
+    /// </summary>
+    /// <param name="statType"></param>
     private void PlayInternal(StatSkillType statType)
     {
         if (_effectMap.TryGetValue(statType, out var data) == false)

--- a/Assets/Scripts/Effect/LevelUp/LevelUpEffectView.cs
+++ b/Assets/Scripts/Effect/LevelUp/LevelUpEffectView.cs
@@ -1,0 +1,127 @@
+using Cysharp.Threading.Tasks;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.VFX;
+
+public class LevelUpEffectView : MonoBehaviour, ISpeedChange
+{
+    public float TimeScale { get; set; } = 1f;
+
+    public void Play(StatSkillType statType)
+    {
+        _effectQueue.Enqueue(statType);
+
+        if (_isPlaying)
+        {
+            return;
+        }
+
+        _isPlaying = true;
+
+        ProcessQueue().Forget();
+    }
+
+
+    public void OnSpeedChange(float scale)
+    {
+        TimeScale = scale;
+
+        // VFXの再生速度を変更
+        _vfx.playRate = TimeScale;
+    }
+
+    [SerializeField] private VisualEffect _vfx;
+
+    [SerializeField]
+    private LevelUpEffectData[] _effectDataArray =
+        new LevelUpEffectData[5];
+
+    [SerializeField]
+    private float _effectDuration = 1.5f;
+
+    private Dictionary<StatSkillType, LevelUpEffectData> _effectMap;
+
+    private Queue<StatSkillType> _effectQueue =
+        new Queue<StatSkillType>();
+
+    private bool _isPlaying;
+
+    private static readonly int SymbolTextureID =
+        Shader.PropertyToID("SymbolTexture");
+
+    private static readonly int SecondaryColorID =
+        Shader.PropertyToID("SecondaryColor");
+
+    private static readonly int LifeColorID =
+        Shader.PropertyToID("ColorOverLife");
+
+    private static readonly int HitEventID =
+        Shader.PropertyToID("hit");
+
+
+    private void Awake()
+    {
+        _effectMap = new Dictionary<StatSkillType, LevelUpEffectData>();
+
+        foreach (var data in _effectDataArray)
+        {
+            _effectMap[data.StatSkillType] = data;
+        }
+    }
+
+    private async UniTask ProcessQueue()
+    {
+        while (_effectQueue.Count > 0)
+        {
+            var statType = _effectQueue.Dequeue();
+
+            PlayInternal(statType);
+
+            await UniTask.WaitForSeconds(
+                _effectDuration,
+                cancellationToken: destroyCancellationToken);
+        }
+
+        _isPlaying = false;
+    }
+
+    private void PlayInternal(StatSkillType statType)
+    {
+        if (_effectMap.TryGetValue(statType, out var data) == false)
+        {
+            Debug.LogWarning(
+                $"[LevelUpEffectView] {statType} の設定がありません。");
+
+            return;
+        }
+
+        _vfx.SetTexture(SymbolTextureID, data.SymbolTexture);
+
+        _vfx.SetVector4(SecondaryColorID, data.SecondaryColor);
+
+        _vfx.SetGradient(LifeColorID, data.ColorOverLife);
+
+        _vfx.SendEvent(HitEventID);
+    }
+}
+
+[Serializable]
+public struct LevelUpEffectData
+{
+    public StatSkillType StatSkillType => _statSkillType;
+    public Texture2D SymbolTexture => _symbolTexture;
+    public Color SecondaryColor => _secondaryColor;
+    public Gradient ColorOverLife => _colorOverLife;
+
+    [SerializeField] private StatSkillType _statSkillType;
+
+    [SerializeField] private Texture2D _symbolTexture;
+
+    [ColorUsage(true, true)]
+    [SerializeField] private Color _secondaryColor;
+
+    [GradientUsage(true)]
+    [SerializeField] private Gradient _colorOverLife;
+}

--- a/Assets/Scripts/Effect/LevelUp/LevelUpEffectView.cs.meta
+++ b/Assets/Scripts/Effect/LevelUp/LevelUpEffectView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: badbec4b346340040af1ab8747066130

--- a/Assets/Scripts/Skill/SkillManager.cs
+++ b/Assets/Scripts/Skill/SkillManager.cs
@@ -6,6 +6,11 @@ using UnityEngine;
 public class SkillManager : MonoBehaviour
 {
     public event Action<SkillBase> OnSkillAcquired;
+    public event Action<StatSkillType> OnApply
+    {
+        add => _statSkillSystem.OnApply += value;
+        remove => _statSkillSystem.OnApply -= value;
+    }
 
     public void Init(IPlayerStats stats, IModeController modeController,
         Transform playerTransform, EnemyManager enemyManager)

--- a/Assets/Scripts/Skill/StatSkillSystem.cs
+++ b/Assets/Scripts/Skill/StatSkillSystem.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 /// <summary>
@@ -6,6 +7,8 @@ using UnityEngine;
 /// </summary>
 public class StatSkillSystem
 {
+    public event Action<StatSkillType> OnApply;
+
     /// <summary>
     /// コンストラクタで、StatSkillData の配列、プレイヤーのステータスインターフェース、EXPManager を受け取る。
     /// </summary>
@@ -42,7 +45,7 @@ public class StatSkillSystem
     {
         if (_statSkillDataArray == null || _statSkillDataArray.Length == 0) return;
 
-        var data = _statSkillDataArray[Random.Range(0, _statSkillDataArray.Length)];
+        var data = _statSkillDataArray[UnityEngine.Random.Range(0, _statSkillDataArray.Length)];
 
         if (data == null)
         {
@@ -94,12 +97,14 @@ public class StatSkillSystem
     {
         switch (type)
         {
-            case StatSkillType.HP: _stats.AddModifier(new DefaultModifier(amount,StatType.Health)); break;
+            case StatSkillType.HP: _stats.AddModifier(new DefaultModifier(amount, StatType.Health)); break;
             case StatSkillType.Attack: _stats.AddModifier(new DefaultModifier(amount, StatType.Attack)); break;
             case StatSkillType.Defense: _stats.AddModifier(new DefaultModifier(amount, StatType.Defense)); break;
             case StatSkillType.Critical: _stats.AddModifier(new DefaultModifier(amount, StatType.CriticalRate)); break;
-            case StatSkillType.Thunder: _stats.AddModifier(new DefaultModifier(amount,StatType.ThunderGauge)); break;
+            case StatSkillType.Thunder: _stats.AddModifier(new DefaultModifier(amount, StatType.ThunderGauge)); break;
         }
+
+        OnApply?.Invoke(type);
     }
 }
 

--- a/Assets/Scripts/System/GameManager.cs
+++ b/Assets/Scripts/System/GameManager.cs
@@ -100,7 +100,7 @@ public class GameManager : MonoBehaviour
 
     private void InitEffect()
     {
-        _playerEffectInitializer.Init(_player);
+        _playerEffectInitializer.Init(_player, _skillManager);
     }
 
     private void InitEXPManager()

--- a/Assets/Scripts/System/PlayerEffectInitializer.cs
+++ b/Assets/Scripts/System/PlayerEffectInitializer.cs
@@ -2,13 +2,25 @@ using UnityEngine;
 
 public class PlayerEffectInitializer : MonoBehaviour
 {
-    public void Init(Player player)
+    public void Init(Player player, SkillManager skillManager)
     {
         //リーク対策
         _thunderEffectPresenter?.Dispose();
         _weaponEffectPresenter?.Dispose();
+        _levelUpEffectPresenter?.Dispose();
+
         _thunderEffectPresenter = null;
         _weaponEffectPresenter = null;
+        _levelUpEffectPresenter = null;
+
+        if (skillManager != null)
+        {
+            _levelUpEffectPresenter = new LevelUpEffectPresenter(_levelUpEffectView, skillManager);
+        }
+        else
+        {
+            Debug.LogError("SkillManagerが見つかりませんでした。");
+        }
 
         if (player.TryGetComponent(out IModeController modeController))
         {
@@ -24,13 +36,16 @@ public class PlayerEffectInitializer : MonoBehaviour
     [SerializeField] private ThunderEffectView _thunderEffect;
     [SerializeField] private WeaponEffectView _thunderEffectView;
     [SerializeField] private WeaponEffectView _warriorEffectView;
+    [SerializeField] private LevelUpEffectView _levelUpEffectView;
 
     private ThunderEffectPresenter _thunderEffectPresenter;
     private WeaponEffectPresenter _weaponEffectPresenter;
+    private LevelUpEffectPresenter _levelUpEffectPresenter;
 
     private void OnDestroy()
     {
         _thunderEffectPresenter?.Dispose();
         _weaponEffectPresenter?.Dispose();
+        _levelUpEffectPresenter?.Dispose();
     }
 }

--- a/Assets/Scripts/UI/Player/GaugeView.cs
+++ b/Assets/Scripts/UI/Player/GaugeView.cs
@@ -40,6 +40,8 @@ public class GaugeView : MonoBehaviour
 
     [SerializeField] private Ease _ease = Ease.Linear;
 
+    [SerializeField] private float _sizeChangeDuration = 0.2f;
+
 
     /// <summary>
     /// HPゲージTween
@@ -59,7 +61,7 @@ public class GaugeView : MonoBehaviour
         float ratio = max / initialMax;
         Vector2 size = _barContainer.sizeDelta;
         size.x = _baseWidth * ratio;
-        _barContainer.sizeDelta = size;
+        _barContainer.DOSizeDelta(size, _sizeChangeDuration);
     }
 
     /// <summary>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * レベルアップ時に青いビジュアルエフェクトが再生されるようになりました（ステータスタイプごとに異なる演出）。
  * スキル適用イベントが公開され、レベルアップエフェクトと連携して自動再生されます。
  * HPゲージ更新時にコンテナ幅の滑らかなアニメーションが追加されました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NaritaShosei/ProjectGO/pull/178)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->