### PR TITLE
最初に後衛Enemyが取り出されるようになっていたのを修正

### DIFF
--- a/Assets/Scripts/Enemy/Mob/Infrastructure/EnemyFormationSystem.cs
+++ b/Assets/Scripts/Enemy/Mob/Infrastructure/EnemyFormationSystem.cs
@@ -121,7 +121,6 @@ public sealed class EnemyFormationSystem : IEnemyFormationSystem
         // 前衛として登録されていない場合は取得不可
         if (!_entries.TryGetValue(enemyId, out var entry) || !entry.IsVanguard)
         {
-            entry.IsVanguard = false;
             return false;
         }
 

--- a/Assets/Scripts/Enemy/Mob/Infrastructure/EnemyFormationSystem.cs
+++ b/Assets/Scripts/Enemy/Mob/Infrastructure/EnemyFormationSystem.cs
@@ -42,6 +42,7 @@ public sealed class EnemyFormationSystem : IEnemyFormationSystem
     /// </summary>
     public void Register(IEnemy enemy, IFormationParticipant participant)
     {
+        Debug.Log($"Register : {enemy.Self.name}");
         if (enemy == null || participant == null) return;
 
         int id = participant.EnemyId;
@@ -119,7 +120,7 @@ public sealed class EnemyFormationSystem : IEnemyFormationSystem
     public bool TryAcquire(int enemyId, int slotCost)
     {
         // 前衛として登録されていない場合は取得不可
-        if (!_entries.TryGetValue(enemyId, out var entry) || entry.IsVanguard)
+        if (!_entries.TryGetValue(enemyId, out var entry) || !entry.IsVanguard)
         {
             entry.IsVanguard = false;
             return false;
@@ -180,6 +181,7 @@ public sealed class EnemyFormationSystem : IEnemyFormationSystem
     /// </summary>
     private void ReevaluateFormation()
     {
+        Debug.Log($"Formation Count : {_entries.Count}");
         int total = _entries.Count;
         if (total == 0) return;
 

--- a/Assets/Scripts/Enemy/Mob/Infrastructure/EnemyFormationSystem.cs
+++ b/Assets/Scripts/Enemy/Mob/Infrastructure/EnemyFormationSystem.cs
@@ -42,7 +42,6 @@ public sealed class EnemyFormationSystem : IEnemyFormationSystem
     /// </summary>
     public void Register(IEnemy enemy, IFormationParticipant participant)
     {
-        Debug.Log($"Register : {enemy.Self.name}");
         if (enemy == null || participant == null) return;
 
         int id = participant.EnemyId;
@@ -181,7 +180,6 @@ public sealed class EnemyFormationSystem : IEnemyFormationSystem
     /// </summary>
     private void ReevaluateFormation()
     {
-        Debug.Log($"Formation Count : {_entries.Count}");
         int total = _entries.Count;
         if (total == 0) return;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 敵のフォーメーション配置において、前衛ユニットのスロット取得可否の条件を調整しました。その結果、前衛ユニットが意図したとおりにスロットを確保できるようになります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->