### PR TITLE
ゴーレムの攻撃エフェクト追加とMobEnemyのアニメーション改善

### DIFF
--- a/Assets/Animation/GolemEnemyAnimator.controller
+++ b/Assets/Animation/GolemEnemyAnimator.controller
@@ -47,7 +47,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAttackSMB
   _attackHitTime: 1.5
-  _weaponSwingTime: 0.6533
+  _weaponSwingTime: 0.55
 --- !u!1102 &-7471881730005279811
 AnimatorState:
   serializedVersion: 6
@@ -402,7 +402,8 @@ AnimatorState:
   m_Transitions:
   - {fileID: 3617620304841174452}
   - {fileID: -4115504339737502035}
-  m_StateMachineBehaviours: []
+  m_StateMachineBehaviours:
+  - {fileID: 4502780900135483804}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -580,6 +581,20 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!114 &4502780900135483804
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2362b8904c559b741a56af2c58f4bc8b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EnemyFootstepSMB
+  _leftFootTime: 0.01
+  _rightFootTime: 0.557
 --- !u!1101 &4630030680606881927
 AnimatorStateTransition:
   m_ObjectHideFlags: 1

--- a/Assets/Animation/GolemEnemyAnimator.controller
+++ b/Assets/Animation/GolemEnemyAnimator.controller
@@ -47,6 +47,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAttackSMB
   _attackHitTime: 1.5
+  _weaponSwingTime: 0.6533
 --- !u!1102 &-7471881730005279811
 AnimatorState:
   serializedVersion: 6
@@ -114,6 +115,7 @@ AnimatorState:
   - {fileID: 1175884930355844829}
   m_StateMachineBehaviours:
   - {fileID: -8270940160055624994}
+  - {fileID: 1272849374352344267}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -462,6 +464,19 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!114 &1272849374352344267
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 824d8ee1413e99946a75ca97238d8699, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EnemyAttackEffectSMB
+  _effectTiming: 0.52
 --- !u!1101 &2814668747069275216
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -549,7 +564,8 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 861195843637033608}
-  m_StateMachineBehaviours: []
+  m_StateMachineBehaviours:
+  - {fileID: 5928899181280400153}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -614,6 +630,18 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!114 &5928899181280400153
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84d2d9bed8e38d744a2cc366d7206454, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EnemyDownStartSMB
 --- !u!1102 &6474621220943160091
 AnimatorState:
   serializedVersion: 6

--- a/Assets/Animation/MobEnemyAnimator.controller
+++ b/Assets/Animation/MobEnemyAnimator.controller
@@ -66,6 +66,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAttackSMB
   _attackHitTime: 0.3
+  _weaponSwingTime: 0.633
 --- !u!114 &-7788459553001155151
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -782,6 +783,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyAttackSMB
   _attackHitTime: 1.09
+  _weaponSwingTime: 0.32
 --- !u!1101 &4997727682768932297
 AnimatorStateTransition:
   m_ObjectHideFlags: 1

--- a/Assets/Animation/MobEnemyAnimator.controller
+++ b/Assets/Animation/MobEnemyAnimator.controller
@@ -53,20 +53,6 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!114 &-8199427681330229961
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a5200d8c2d418da4fa93ffc4b1d5f391, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::EnemyAttackSMB
-  _attackHitTime: 0.3
-  _weaponSwingTime: 0.633
 --- !u!114 &-7788459553001155151
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1088,7 +1074,6 @@ AnimatorState:
   - {fileID: 8964058316493861854}
   m_StateMachineBehaviours:
   - {fileID: 4630767809863787672}
-  - {fileID: -8199427681330229961}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1

--- a/Assets/Animation/MobEnemyAnimator.controller
+++ b/Assets/Animation/MobEnemyAnimator.controller
@@ -53,6 +53,19 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!114 &-8199427681330229961
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5200d8c2d418da4fa93ffc4b1d5f391, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EnemyAttackSMB
+  _attackHitTime: 0.3
 --- !u!114 &-7788459553001155151
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1073,6 +1086,7 @@ AnimatorState:
   - {fileID: 8964058316493861854}
   m_StateMachineBehaviours:
   - {fileID: 4630767809863787672}
+  - {fileID: -8199427681330229961}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1

--- a/Assets/Animation/MobEnemyAnimator.controller
+++ b/Assets/Animation/MobEnemyAnimator.controller
@@ -714,7 +714,7 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
-  - m_ConditionMode: 3
+  - m_ConditionMode: 4
     m_ConditionEvent: Speed
     m_EventTreshold: -0.1
   m_DstStateMachine: {fileID: 0}

--- a/Assets/Prefab/Enemy/Mob/StoneGolem.prefab
+++ b/Assets/Prefab/Enemy/Mob/StoneGolem.prefab
@@ -351,6 +351,7 @@ GameObject:
   - component: {fileID: 7301585828367876861}
   - component: {fileID: 6158760630654705163}
   - component: {fileID: 5989024217522494440}
+  - component: {fileID: 5136796591454539382}
   m_Layer: 8
   m_Name: StoneGolem
   m_TagString: Untagged
@@ -394,6 +395,8 @@ MonoBehaviour:
   _turnProfile: {fileID: 11400000, guid: 84c85403bc40a3c47b61cd25c0d667a0, type: 2}
   _distanceProfile: {fileID: 11400000, guid: d64c95ea40de26a458c660c4cc596173, type: 2}
   _animationEventReceiver: {fileID: 7696763789007296301}
+  _soundHandler: {fileID: 5136796591454539382}
+  _enemyType: 1
   _armor: {fileID: 2232957639341954153}
   _downDuration: 5
   _bodyRenderer:
@@ -455,6 +458,18 @@ CapsuleCollider:
   m_Height: 1
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &5136796591454539382
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 315166858859022630}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3228565db4b453e42b723817d49cbe9b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EnemySoundHandler
 --- !u!1 &336853683618154536
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefab/Enemy/Mob/StoneGolem.prefab
+++ b/Assets/Prefab/Enemy/Mob/StoneGolem.prefab
@@ -401,6 +401,8 @@ MonoBehaviour:
   _blinkSpeed: 100
   _attackCooldownOverride: 5
   _barkChance: 0.52
+  _attackEffectPoint: {fileID: 4792808834329252107}
+  _attackEffecktText: "\u5927\u5730\u7C89\u7815"
 --- !u!114 &6158760630654705163
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -682,6 +684,7 @@ Transform:
   - {fileID: 3552210386689605197}
   - {fileID: 1277519113122577122}
   - {fileID: 7655169624917475776}
+  - {fileID: 4792808834329252107}
   m_Father: {fileID: 1086601411383579548}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &4821917941713793549
@@ -1254,6 +1257,37 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1277519113122577122}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2398836030666444658
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4792808834329252107}
+  m_Layer: 0
+  m_Name: GameObject (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4792808834329252107
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2398836030666444658}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.562, y: 0, z: -0.07}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6348492763003575672}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2428512062954499080
 GameObject:

--- a/Assets/Prefab/Test/TestArmoredMobEnemy.prefab
+++ b/Assets/Prefab/Test/TestArmoredMobEnemy.prefab
@@ -45,6 +45,7 @@ GameObject:
   - component: {fileID: 640612532259396523}
   - component: {fileID: -8330086056522255198}
   - component: {fileID: 8057836371575198857}
+  - component: {fileID: 5150607616298102398}
   m_Layer: 8
   m_Name: TestArmoredMobEnemy
   m_TagString: Untagged
@@ -166,6 +167,8 @@ MonoBehaviour:
   _turnProfile: {fileID: 11400000, guid: 362aa867931ba5444ae43e73f8223e3e, type: 2}
   _distanceProfile: {fileID: 11400000, guid: 28f4a609b4f245e4e8ec74a84e56b62b, type: 2}
   _animationEventReceiver: {fileID: 6344822612628370091}
+  _soundHandler: {fileID: 5150607616298102398}
+  _enemyType: 0
   _armor: {fileID: 186864388146565}
 --- !u!114 &8057836371575198857
 MonoBehaviour:
@@ -211,6 +214,18 @@ MonoBehaviour:
     _id: "\u93A7\u7834\u58CA"
     _effectKeys:
     - "\u30C6\u30B9\u30C8\u30A2\u30FC\u30DE\u30FC\u7834\u58CA"
+--- !u!114 &5150607616298102398
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5851137478512212370}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3228565db4b453e42b723817d49cbe9b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EnemySoundHandler
 --- !u!1001 &3207627424300379340
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/TestScenes/UITestScene.unity
+++ b/Assets/Scenes/TestScenes/UITestScene.unity
@@ -979,6 +979,86 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1001 &653596892
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5557725580132027205, guid: 6da08b1262fd0454eb17f2ac2763dcd5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4373.7524
+      objectReference: {fileID: 0}
+    - target: {fileID: 5557725580132027205, guid: 6da08b1262fd0454eb17f2ac2763dcd5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.00005
+      objectReference: {fileID: 0}
+    - target: {fileID: 5557725580132027205, guid: 6da08b1262fd0454eb17f2ac2763dcd5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2397.1482
+      objectReference: {fileID: 0}
+    - target: {fileID: 5557725580132027205, guid: 6da08b1262fd0454eb17f2ac2763dcd5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5557725580132027205, guid: 6da08b1262fd0454eb17f2ac2763dcd5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5557725580132027205, guid: 6da08b1262fd0454eb17f2ac2763dcd5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5557725580132027205, guid: 6da08b1262fd0454eb17f2ac2763dcd5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5557725580132027205, guid: 6da08b1262fd0454eb17f2ac2763dcd5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5557725580132027205, guid: 6da08b1262fd0454eb17f2ac2763dcd5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5557725580132027205, guid: 6da08b1262fd0454eb17f2ac2763dcd5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5851137478512212370, guid: 6da08b1262fd0454eb17f2ac2763dcd5, type: 3}
+      propertyPath: m_Name
+      value: TestArmoredMobEnemy
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6da08b1262fd0454eb17f2ac2763dcd5, type: 3}
+--- !u!1 &662488341
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 961530871842838584, guid: 74267bc9deb974c4a80c2c11b7f619dd, type: 3}
+  m_PrefabInstance: {fileID: 203619188}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 894509692}
+  - component: {fileID: 894509685}
+  - component: {fileID: 894509691}
+  - component: {fileID: 894509690}
+  - component: {fileID: 894509689}
+  - component: {fileID: 894509688}
+  - component: {fileID: 894509687}
+  - component: {fileID: 894509686}
+  m_Layer: 0
+  m_Name: FreeLook Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!114 &726188473 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8940264381597593894, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
@@ -1252,17 +1332,278 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1c7b18a0c327a324aad7405a9dbc16ec, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::GaugeView
---- !u!114 &894509685 stripped
+--- !u!114 &894509685
 MonoBehaviour:
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 1622099667948176317, guid: 74267bc9deb974c4a80c2c11b7f619dd, type: 3}
   m_PrefabInstance: {fileID: 203619188}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 662488341}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineCamera
+  Priority:
+    Enabled: 1
+    m_Value: 10
+  OutputChannel: 1
+  StandbyUpdate: 2
+  m_StreamingVersion: 20241001
+  m_LegacyPriority: 0
+  Target:
+    TrackingTarget: {fileID: 0}
+    LookAtTarget: {fileID: 0}
+    CustomLookAtTarget: 0
+  Lens:
+    FieldOfView: 55
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    PhysicalProperties:
+      GateFit: 2
+      SensorSize: {x: 21.946, y: 16.002}
+      LensShift: {x: 0, y: 0}
+      FocusDistance: 10
+      Iso: 200
+      ShutterSpeed: 0.005
+      Aperture: 16
+      BladeCount: 5
+      Curvature: {x: 2, y: 11}
+      BarrelClipping: 0.25
+      Anamorphism: 0
+  BlendHint: 0
+--- !u!114 &894509686
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 2569257103208793588, guid: 74267bc9deb974c4a80c2c11b7f619dd, type: 3}
+  m_PrefabInstance: {fileID: 203619188}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662488341}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68bb026fafb42b14791938953eaace77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineBasicMultiChannelPerlin
+  NoiseProfile: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4, type: 2}
+  PivotOffset: {x: 0, y: 0, z: 0}
+  AmplitudeGain: 1
+  FrequencyGain: 1
+  m_NoiseOffsets: {x: 0, y: 0, z: 0}
+--- !u!114 &894509687
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 6314859575784271827, guid: 74267bc9deb974c4a80c2c11b7f619dd, type: 3}
+  m_PrefabInstance: {fileID: 203619188}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662488341}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ca7de3aefa901374ba29464584a3109a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineDecollider
+  CameraRadius: 0.4
+  Decollision:
+    Enabled: 1
+    ObstacleLayers:
+      serializedVersion: 2
+      m_Bits: 4294967295
+    UseFollowTarget:
+      Enabled: 0
+      YOffset: 0
+    Damping: 0.5
+    SmoothingTime: 0
+  TerrainResolution:
+    Enabled: 1
+    TerrainLayers:
+      serializedVersion: 2
+      m_Bits: 1
+    MaximumRaycast: 10
+    Damping: 0.5
+--- !u!114 &894509688
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 1118617712252912988, guid: 74267bc9deb974c4a80c2c11b7f619dd, type: 3}
+  m_PrefabInstance: {fileID: 203619188}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662488341}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89875cdc57c54474a8a74efd9b2a3b5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineInputAxisController
+  ScanRecursively: 1
+  SuppressInputWhileBlending: 1
+  IgnoreTimeScale: 0
+  m_ControllerManager:
+    Controllers:
+    - Name: Look Orbit X
+      Owner: {fileID: 894509691}
+      Enabled: 1
+      Input:
+        InputAction: {fileID: -5630151704836100654, guid: 1d6e640e716dc4ff6989b73d02023f2b, type: 3}
+        Gain: 1
+        LegacyInput: 
+        LegacyGain: 1
+        CancelDeltaTime: 0
+      InputValue: 0
+      Driver:
+        AccelTime: 0.2
+        DecelTime: 0.2
+    - Name: Look Orbit Y
+      Owner: {fileID: 894509691}
+      Enabled: 1
+      Input:
+        InputAction: {fileID: -5630151704836100654, guid: 1d6e640e716dc4ff6989b73d02023f2b, type: 3}
+        Gain: -1
+        LegacyInput: 
+        LegacyGain: 1
+        CancelDeltaTime: 0
+      InputValue: 0
+      Driver:
+        AccelTime: 0.2
+        DecelTime: 0.2
+    - Name: Orbit Scale
+      Owner: {fileID: 894509691}
+      Enabled: 1
+      Input:
+        InputAction: {fileID: 5082991133974614888, guid: 1d6e640e716dc4ff6989b73d02023f2b, type: 3}
+        Gain: -1
+        LegacyInput: 
+        LegacyGain: 1
+        CancelDeltaTime: 0
+      InputValue: 0
+      Driver:
+        AccelTime: 0
+        DecelTime: 0
+  PlayerIndex: -1
+  AutoEnableInputs: 1
+--- !u!114 &894509689
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 6372492811266483842, guid: 74267bc9deb974c4a80c2c11b7f619dd, type: 3}
+  m_PrefabInstance: {fileID: 203619188}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662488341}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a076c17fe76165e4f8ed21498b877bf9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineFreeLookModifier
+  Easing: 0
+  Modifiers: []
+  references:
+    version: 2
+    RefIds: []
+--- !u!114 &894509690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 3024584072184093913, guid: 74267bc9deb974c4a80c2c11b7f619dd, type: 3}
+  m_PrefabInstance: {fileID: 203619188}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662488341}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f38bda98361e1de48a4ca2bd86ea3c17, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineRotationComposer
+  Composition:
+    ScreenPosition: {x: 0, y: 0.3}
+    DeadZone:
+      Enabled: 0
+      Size: {x: 0.2, y: 0.2}
+    HardLimits:
+      Enabled: 0
+      Size: {x: 0.8, y: 0.8}
+      Offset: {x: 0, y: 0}
+  CenterOnActivate: 1
+  TargetOffset: {x: 0, y: 0, z: 0}
+  Damping: {x: 0.5, y: 0.5}
+  Lookahead:
+    Enabled: 0
+    Time: 0
+    Smoothing: 0
+    IgnoreY: 0
+--- !u!114 &894509691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 167389161284933562, guid: 74267bc9deb974c4a80c2c11b7f619dd, type: 3}
+  m_PrefabInstance: {fileID: 203619188}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662488341}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b5d7c088409d9a40b7b09aa707777f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineOrbitalFollow
+  TargetOffset: {x: 0, y: 0, z: 0}
+  TrackerSettings:
+    BindingMode: 4
+    PositionDamping: {x: 0, y: 0, z: 0}
+    AngularDampingMode: 0
+    RotationDamping: {x: 1, y: 1, z: 1}
+    QuaternionDamping: 1
+  OrbitStyle: 1
+  Radius: 5
+  Orbits:
+    Top:
+      Radius: 2
+      Height: 5
+    Center:
+      Radius: 4
+      Height: 2.25
+    Bottom:
+      Radius: 2.5
+      Height: 0.1
+    SplineCurvature: 0.5
+  RecenteringTarget: 2
+  HorizontalAxis:
+    Value: 0
+    Center: 0
+    Range: {x: -180, y: 180}
+    Wrap: 1
+    Recentering:
+      Enabled: 0
+      Wait: 1
+      Time: 2
+    Restrictions: 0
+  VerticalAxis:
+    Value: 17.5
+    Center: 17.5
+    Range: {x: -10, y: 45}
+    Wrap: 0
+    Recentering:
+      Enabled: 0
+      Wait: 1
+      Time: 2
+    Restrictions: 0
+  RadialAxis:
+    Value: 1
+    Center: 1
+    Range: {x: 1, y: 1}
+    Wrap: 0
+    Recentering:
+      Enabled: 0
+      Wait: 1
+      Time: 2
+    Restrictions: 0
+--- !u!4 &894509692
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 6166178355341034140, guid: 74267bc9deb974c4a80c2c11b7f619dd, type: 3}
+  m_PrefabInstance: {fileID: 203619188}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662488341}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.104633205, y: -0.000000020438375, z: 0.0000000021503366, w: 0.9945109}
+  m_LocalPosition: {x: -1.66124, y: 0, z: 14.4811}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &997946918 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5996334519932279739, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
@@ -2342,3 +2683,4 @@ SceneRoots:
   - {fileID: 1286083919}
   - {fileID: 207396567}
   - {fileID: 245819969}
+  - {fileID: 653596892}

--- a/Assets/Scripts/Data/Enemy/Mob/EnemyType.cs
+++ b/Assets/Scripts/Data/Enemy/Mob/EnemyType.cs
@@ -1,0 +1,9 @@
+/// <summary>
+/// 敵種別
+/// SEやエフェクトなど敵ごとの分岐に使用する
+/// </summary>
+public enum EnemyType
+{
+    Draugr,
+    StoneGolem
+}

--- a/Assets/Scripts/Data/Enemy/Mob/EnemyType.cs.meta
+++ b/Assets/Scripts/Data/Enemy/Mob/EnemyType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 484f71a55914b224c874e095410e5cca

--- a/Assets/Scripts/Enemy/Golem/GolemEnemy.cs
+++ b/Assets/Scripts/Enemy/Golem/GolemEnemy.cs
@@ -1,5 +1,6 @@
-using UnityEngine;
 using System;
+using UnityEngine;
+using static UnityEditor.PlayerSettings;
 
 /// <summary>
 /// ゴーレム専用Enemy
@@ -249,7 +250,9 @@ public class GolemEnemy : MobEnemy, IFormationParticipant
 
     protected override void HandleAttackEffect()
     {
-        _effectManager?.PlayEffect(_attackEffecktText, _attackEffectPoint.position);
+        if (_effectManager == null) return;
+        Vector3 pos = _attackEffectPoint != null ? _attackEffectPoint.position : transform.position;
+        _effectManager.PlayEffect(_attackEffecktText, pos);
     }
     private void HandleDownStart()
     {

--- a/Assets/Scripts/Enemy/Golem/GolemEnemy.cs
+++ b/Assets/Scripts/Enemy/Golem/GolemEnemy.cs
@@ -133,6 +133,8 @@ public class GolemEnemy : MobEnemy, IFormationParticipant
         _armor.Restore();
         RebindArmor();
         _defenceContext.EnemyType = EnemyDefenceType.Armor;
+
+        InvokeArmorRegistered();
     }
 
     [Header("Down Settings")]

--- a/Assets/Scripts/Enemy/Golem/GolemEnemy.cs
+++ b/Assets/Scripts/Enemy/Golem/GolemEnemy.cs
@@ -1,6 +1,5 @@
 using System;
 using UnityEngine;
-using static UnityEditor.PlayerSettings;
 
 /// <summary>
 /// ゴーレム専用Enemy

--- a/Assets/Scripts/Enemy/Golem/GolemEnemy.cs
+++ b/Assets/Scripts/Enemy/Golem/GolemEnemy.cs
@@ -8,7 +8,6 @@ using static UnityEditor.PlayerSettings;
 /// </summary>
 public class GolemEnemy : MobEnemy, IFormationParticipant
 {
-    public event Action OnDownStarted;
     /// <summary>
     /// ゴーレムの初期化
     /// Behaviour・Condition・Armorを生成して登録する
@@ -253,10 +252,6 @@ public class GolemEnemy : MobEnemy, IFormationParticipant
         if (_effectManager == null) return;
         Vector3 pos = _attackEffectPoint != null ? _attackEffectPoint.position : transform.position;
         _effectManager.PlayEffect(_attackEffecktText, pos);
-    }
-    private void HandleDownStart()
-    {
-        OnDownStarted?.Invoke();
     }
 
     /// <summary>

--- a/Assets/Scripts/Enemy/Golem/GolemEnemy.cs
+++ b/Assets/Scripts/Enemy/Golem/GolemEnemy.cs
@@ -7,6 +7,7 @@ using System;
 /// </summary>
 public class GolemEnemy : MobEnemy, IFormationParticipant
 {
+    public event Action OnDownStarted;
     /// <summary>
     /// ゴーレムの初期化
     /// Behaviour・Condition・Armorを生成して登録する
@@ -249,6 +250,10 @@ public class GolemEnemy : MobEnemy, IFormationParticipant
     protected override void HandleAttackEffect()
     {
         _effectManager?.PlayEffect(_attackEffecktText, _attackEffectPoint.position);
+    }
+    private void HandleDownStart()
+    {
+        OnDownStarted?.Invoke();
     }
 
     /// <summary>

--- a/Assets/Scripts/Enemy/Golem/GolemEnemy.cs
+++ b/Assets/Scripts/Enemy/Golem/GolemEnemy.cs
@@ -16,6 +16,7 @@ public class GolemEnemy : MobEnemy, IFormationParticipant
         base.Init();
 
         _blinkEffect = new BlinkEffect(_bodyRenderer,_blinkSpeed);
+        _effectManager = ServiceLocator.Get<EffectManager>();
 
         OnArmorBroken += HandleArmorBroken;
 
@@ -155,7 +156,14 @@ public class GolemEnemy : MobEnemy, IFormationParticipant
 
     [SerializeField, Range(0f, 1f), Tooltip("攻撃後に威嚇へ移行する確率")] private float _barkChance = 0.5f;
 
+    [SerializeField]
+    private Transform _attackEffectPoint;
+
+    [SerializeField]
+    private String _attackEffecktText;
+
     private BlinkEffect _blinkEffect;
+    private EffectManager _effectManager;
 
     /// <summary>
     /// オブジェクト破棄時にイベント購読を解除し、BlinkEffectを停止する
@@ -236,6 +244,11 @@ public class GolemEnemy : MobEnemy, IFormationParticipant
             move.Init(initCtx);
             _runner.Register(move);
         }
+    }
+
+    protected override void HandleAttackEffect()
+    {
+        _effectManager?.PlayEffect(_attackEffecktText, _attackEffectPoint.position);
     }
 
     /// <summary>

--- a/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimationEventReceiver.cs
+++ b/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimationEventReceiver.cs
@@ -29,7 +29,14 @@ public class EnemyAnimationEventReceiver : MonoBehaviour, IEnemyAnimationControl
 
     public event Action OnDownEnd;
 
+    /// <summary>Downスタート時のイベント</summary>
+    public event Action OnDownStart;
+    /// <summary>攻撃開始時のイベント</summary>
     public event Action OnAttackEffect;
+    /// <summary>歩行時のイベント</summary>
+    public event Action OnFootstep;
+    /// <summary>Barkアニメーション開始</summary>
+    public event Action OnBarkStart;
 
     /// <summary>EnemyAttackSMB から攻撃ヒットタイミングで呼ばれる</summary>
     public void AnimEvent_AttackHit()
@@ -66,13 +73,27 @@ public class EnemyAnimationEventReceiver : MonoBehaviour, IEnemyAnimationControl
     {
         OnDeadEnd?.Invoke();
     }
+
     public void AnimEvent_DownEnd()
     {
         OnDownEnd?.Invoke();
     }
 
+    public void AnimEvent_DownStart()
+    {
+        OnDownStart?.Invoke();
+    }
+
     public void AnimEvent_AttackEffect()
     {
         OnAttackEffect?.Invoke();
+    }
+    public void AnimEvent_Footstep()
+    {
+        OnFootstep?.Invoke();
+    }
+    public void AnimEvent_BarkStart()
+    {
+        OnBarkStart?.Invoke();
     }
 }

--- a/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimationEventReceiver.cs
+++ b/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimationEventReceiver.cs
@@ -39,6 +39,8 @@ public class EnemyAnimationEventReceiver : MonoBehaviour, IEnemyAnimationControl
     public event Action OnBarkStart;
     /// <summary>攻撃開始イベント</summary>
     public event Action OnAttackStart;
+    /// <summary>武器スイングSEイベント</summary>
+    public event Action OnWeaponSwing;
 
     /// <summary>EnemyAttackSMB から攻撃ヒットタイミングで呼ばれる</summary>
     public void AnimEvent_AttackHit()
@@ -98,8 +100,14 @@ public class EnemyAnimationEventReceiver : MonoBehaviour, IEnemyAnimationControl
     {
         OnBarkStart?.Invoke();
     }
+
     public void AnimEvent_AttackStart()
     {
         OnAttackStart?.Invoke();
+    }
+
+    public void AnimEvent_WeaponSwing()
+    {
+        OnWeaponSwing?.Invoke();
     }
 }

--- a/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimationEventReceiver.cs
+++ b/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimationEventReceiver.cs
@@ -37,6 +37,8 @@ public class EnemyAnimationEventReceiver : MonoBehaviour, IEnemyAnimationControl
     public event Action OnFootstep;
     /// <summary>Barkアニメーション開始</summary>
     public event Action OnBarkStart;
+    /// <summary>攻撃開始イベント</summary>
+    public event Action OnAttackStart;
 
     /// <summary>EnemyAttackSMB から攻撃ヒットタイミングで呼ばれる</summary>
     public void AnimEvent_AttackHit()
@@ -95,5 +97,9 @@ public class EnemyAnimationEventReceiver : MonoBehaviour, IEnemyAnimationControl
     public void AnimEvent_BarkStart()
     {
         OnBarkStart?.Invoke();
+    }
+    public void AnimEvent_AttackStart()
+    {
+        OnAttackStart?.Invoke();
     }
 }

--- a/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimationEventReceiver.cs
+++ b/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimationEventReceiver.cs
@@ -29,6 +29,8 @@ public class EnemyAnimationEventReceiver : MonoBehaviour, IEnemyAnimationControl
 
     public event Action OnDownEnd;
 
+    public event Action OnAttackEffect;
+
     /// <summary>EnemyAttackSMB から攻撃ヒットタイミングで呼ばれる</summary>
     public void AnimEvent_AttackHit()
     {
@@ -67,5 +69,10 @@ public class EnemyAnimationEventReceiver : MonoBehaviour, IEnemyAnimationControl
     public void AnimEvent_DownEnd()
     {
         OnDownEnd?.Invoke();
+    }
+
+    public void AnimEvent_AttackEffect()
+    {
+        OnAttackEffect?.Invoke();
     }
 }

--- a/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimator.cs
+++ b/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimator.cs
@@ -20,6 +20,7 @@ public class EnemyAnimator : IEnemyAnimator
     public event Action OnFootstep;
     public event Action OnBarkStart;
     public event Action OnAttackStart;
+    public event Action OnWeaponSwing;
 
     /// <summary>
     /// コンストラクタ。ReceiverのイベントをEnemyAnimatorへ中継する。
@@ -43,6 +44,7 @@ public class EnemyAnimator : IEnemyAnimator
         _receiver.OnFootstep += HandleFootstep;
         _receiver.OnBarkStart += HandleBarkStart;
         _receiver.OnAttackStart += HandleAttackStart;
+        _receiver.OnWeaponSwing += HandleWeaponSwing;
     }
 
     /// <summary>
@@ -137,6 +139,7 @@ public class EnemyAnimator : IEnemyAnimator
         _receiver.OnFootstep -= HandleFootstep;
         _receiver.OnBarkStart -= HandleBarkStart;
         _receiver.OnAttackStart -= HandleAttackStart;
+        _receiver.OnWeaponSwing -= HandleWeaponSwing;
     }
 
     public void SetDown(bool value)
@@ -180,4 +183,5 @@ public class EnemyAnimator : IEnemyAnimator
     private void HandleFootstep() => OnFootstep?.Invoke();
     private void HandleBarkStart() => OnBarkStart?.Invoke();
     private void HandleAttackStart() => OnAttackStart?.Invoke();
+    private void HandleWeaponSwing() => OnWeaponSwing?.Invoke();
 }

--- a/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimator.cs
+++ b/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimator.cs
@@ -19,6 +19,7 @@ public class EnemyAnimator : IEnemyAnimator
     public event Action OnDownStart;
     public event Action OnFootstep;
     public event Action OnBarkStart;
+    public event Action OnAttackStart;
 
     /// <summary>
     /// コンストラクタ。ReceiverのイベントをEnemyAnimatorへ中継する。
@@ -41,6 +42,7 @@ public class EnemyAnimator : IEnemyAnimator
         _receiver.OnAttackEffect += HandleAttackEffect;
         _receiver.OnFootstep += HandleFootstep;
         _receiver.OnBarkStart += HandleBarkStart;
+        _receiver.OnAttackStart += HandleAttackStart;
     }
 
     /// <summary>
@@ -134,6 +136,7 @@ public class EnemyAnimator : IEnemyAnimator
         _receiver.OnAttackEffect -= HandleAttackEffect;
         _receiver.OnFootstep -= HandleFootstep;
         _receiver.OnBarkStart -= HandleBarkStart;
+        _receiver.OnAttackStart -= HandleAttackStart;
     }
 
     public void SetDown(bool value)
@@ -176,4 +179,5 @@ public class EnemyAnimator : IEnemyAnimator
     private void HandleAttackEffect() => OnAttackEffect?.Invoke();
     private void HandleFootstep() => OnFootstep?.Invoke();
     private void HandleBarkStart() => OnBarkStart?.Invoke();
+    private void HandleAttackStart() => OnAttackStart?.Invoke();
 }

--- a/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimator.cs
+++ b/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimator.cs
@@ -15,6 +15,10 @@ public class EnemyAnimator : IEnemyAnimator
     public event Action OnKnockbackEnd;
     public event Action OnDeadEnd;
     public event Action OnDownEnd;
+    public event Action OnAttackEffect;
+    public event Action OnDownStart;
+    public event Action OnFootstep;
+    public event Action OnBarkStart;
 
     /// <summary>
     /// コンストラクタ。ReceiverのイベントをEnemyAnimatorへ中継する。
@@ -33,6 +37,10 @@ public class EnemyAnimator : IEnemyAnimator
         _receiver.OnKnockbackEnd += HandleKnockbackEnd;
         _receiver.OnDeadEnd += HandleDeadEnd;
         _receiver.OnDownEnd += HandleDownEnd;
+        _receiver.OnDownStart += HandleDownStart;
+        _receiver.OnAttackEffect += HandleAttackEffect;
+        _receiver.OnFootstep += HandleFootstep;
+        _receiver.OnBarkStart += HandleBarkStart;
     }
 
     /// <summary>
@@ -122,6 +130,10 @@ public class EnemyAnimator : IEnemyAnimator
         _receiver.OnKnockbackEnd -= HandleKnockbackEnd;
         _receiver.OnDeadEnd -= HandleDeadEnd;
         _receiver.OnDownEnd -= HandleDownEnd;
+        _receiver.OnDownStart -= HandleDownStart;
+        _receiver.OnAttackEffect -= HandleAttackEffect;
+        _receiver.OnFootstep -= HandleFootstep;
+        _receiver.OnBarkStart -= HandleBarkStart;
     }
 
     public void SetDown(bool value)
@@ -160,4 +172,8 @@ public class EnemyAnimator : IEnemyAnimator
     private void HandleKnockbackEnd() => OnKnockbackEnd?.Invoke();
     private void HandleDeadEnd() => OnDeadEnd?.Invoke();
     private void HandleDownEnd() => OnDownEnd?.Invoke();
+    private void HandleDownStart() => OnDownStart?.Invoke();
+    private void HandleAttackEffect() => OnAttackEffect();
+    private void HandleFootstep() => OnFootstep?.Invoke();
+    private void HandleBarkStart() => OnBarkStart?.Invoke();
 }

--- a/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimator.cs
+++ b/Assets/Scripts/Enemy/Mob/Animation/EnemyAnimator.cs
@@ -173,7 +173,7 @@ public class EnemyAnimator : IEnemyAnimator
     private void HandleDeadEnd() => OnDeadEnd?.Invoke();
     private void HandleDownEnd() => OnDownEnd?.Invoke();
     private void HandleDownStart() => OnDownStart?.Invoke();
-    private void HandleAttackEffect() => OnAttackEffect();
+    private void HandleAttackEffect() => OnAttackEffect?.Invoke();
     private void HandleFootstep() => OnFootstep?.Invoke();
     private void HandleBarkStart() => OnBarkStart?.Invoke();
 }

--- a/Assets/Scripts/Enemy/Mob/Behaviours/BarkBehaviour.cs
+++ b/Assets/Scripts/Enemy/Mob/Behaviours/BarkBehaviour.cs
@@ -57,6 +57,7 @@ public class BarkBehaviour : IEnemyBehaviour
         bool hasNoSlot = !_attackerSlot.IsAcquired(_enemyId);
         if (!isOnCooldown && !hasNoSlot) return false;
 
+
         // 確率判定：falseのときはRoamが選ばれる
         return UnityEngine.Random.value < _barkChance;
     }

--- a/Assets/Scripts/Enemy/Mob/Core/Enemy.cs
+++ b/Assets/Scripts/Enemy/Mob/Core/Enemy.cs
@@ -2,6 +2,7 @@ using Cysharp.Threading.Tasks;
 using System;
 using System.Threading;
 using UnityEngine;
+using static EnemyServices;
 
 /// <summary>
 /// Enemyの基底クラス
@@ -24,8 +25,14 @@ public abstract class Enemy : MonoBehaviour, IEnemy, ISpeedChange, IPoolable
     //HitEffect発生を外部（レシーバーやエフェクトマネージャーなど）に通知するイベント
     public event Action<HitEffectContext> OnHitEffect;
 
+    //SE関係のイベント
+    public event Action OnAttackSE;
+    public event Action OnBarkSE;
+    public event Action OnDownSE;
+
     public virtual IEnemyConditionController ConditionController { get; }
     public IEnemyAnimator EnemyAnimator => _enemyAnimator;
+    public EnemyType EnemyType => _enemyType;
 
     public Transform Self { get => transform; }
 
@@ -229,6 +236,11 @@ public abstract class Enemy : MonoBehaviour, IEnemy, ISpeedChange, IPoolable
     // EnemyAnimatorと同じGameObjectにアタッチされたReceiverへの参照
     [SerializeField] private EnemyAnimationEventReceiver _animationEventReceiver;
 
+    //SEのハンドラー
+    [SerializeField]private EnemySoundHandler _soundHandler;
+
+    [SerializeField]private EnemyType _enemyType;
+
     protected EnemyDefenseContext _defenceContext;
     protected EnemyStats _stats;
     protected Transform _playerTransform;
@@ -284,6 +296,7 @@ public abstract class Enemy : MonoBehaviour, IEnemy, ISpeedChange, IPoolable
         {
             _animationEventReceiver.OnAttackEffect += HandleAttackEffect;
         }
+        _soundHandler?.Init(this);
     }
 
     protected virtual void Update()
@@ -363,6 +376,17 @@ public abstract class Enemy : MonoBehaviour, IEnemy, ISpeedChange, IPoolable
 
     protected virtual void HandleAttackEffect()
     {
+        OnAttackSE?.Invoke();
+    }
+
+    protected void InvokeOnBarkSE()
+    {
+        OnBarkSE?.Invoke();
+    }
+
+    protected void InvokeOnDownSE()
+    {
+        OnDownSE?.Invoke();
     }
 
     /// <summary>

--- a/Assets/Scripts/Enemy/Mob/Core/Enemy.cs
+++ b/Assets/Scripts/Enemy/Mob/Core/Enemy.cs
@@ -279,6 +279,11 @@ public abstract class Enemy : MonoBehaviour, IEnemy, ISpeedChange, IPoolable
         _enemyAnimator = new EnemyAnimator(_animator, _animationEventReceiver);
         // 死亡アニメーション終了イベントを購読する
         _enemyAnimator.OnDeadEnd += HandleDeadEnd;
+
+        if (_animationEventReceiver != null)
+        {
+            _animationEventReceiver.OnAttackEffect += HandleAttackEffect;
+        }
     }
 
     protected virtual void Update()
@@ -322,6 +327,11 @@ public abstract class Enemy : MonoBehaviour, IEnemy, ISpeedChange, IPoolable
             _enemyAnimator.OnDeadEnd -= HandleDeadEnd;
             _enemyAnimator.Dispose();
         }
+
+        if (_animationEventReceiver != null)
+        {
+            _animationEventReceiver.OnAttackEffect -= HandleAttackEffect;
+        }
     }
 
     /// <summary>
@@ -349,6 +359,10 @@ public abstract class Enemy : MonoBehaviour, IEnemy, ISpeedChange, IPoolable
         // 死亡アニメーション完了を待ってから破棄する
         // (済み): ObjectPool導入時は WaitForDeadAnimationAndDeactivate() に切り替える
         WaitForDeadAnimationAndDeactivate().Forget();
+    }
+
+    protected virtual void HandleAttackEffect()
+    {
     }
 
     /// <summary>

--- a/Assets/Scripts/Enemy/Mob/MobEnemy.cs
+++ b/Assets/Scripts/Enemy/Mob/MobEnemy.cs
@@ -43,7 +43,7 @@ public class MobEnemy : Enemy, IFormationParticipant
             _armor.Init(this);
             _armor.OnBroken += BreakArmor;
             // Init()後に発火することで購読者がOnHealthChangedを安全に受け取れる
-            OnArmorRegistered?.Invoke(_armor);
+            InvokeArmorRegistered();
         }
         else
         {
@@ -304,6 +304,14 @@ public class MobEnemy : Enemy, IFormationParticipant
         var idle = new IdleBehaviour();
         idle.Init(initCtx);
         _runner.Register(idle);
+    }
+
+    /// <summary>
+    /// Armor登録イベントを発火する
+    /// </summary>
+    protected void InvokeArmorRegistered()
+    {
+        OnArmorRegistered?.Invoke(_armor);
     }
 
     /// <summary>

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackEffectSMB.cs
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackEffectSMB.cs
@@ -2,8 +2,8 @@ using UnityEngine;
 
 public class EnemyAttackEffectSMB : StateMachineBehaviour
 {
-    [Header("Timings (seconds)")]
-    [SerializeField]
+    [Header("Effect Timing (normalized 0-1)")]
+    [SerializeField,Range(0f, 1f)]
     private float _effectTiming = 0.2f;
 
     private bool _effectFired; 

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackEffectSMB.cs
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackEffectSMB.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+public class EnemyAttackEffectSMB : StateMachineBehaviour
+{
+    [Header("Timings (seconds)")]
+    [SerializeField]
+    private float _effectTiming = 0.2f;
+
+    private bool _effectFired; 
+
+    public override void OnStateEnter (Animator animator, AnimatorStateInfo stateInfo,int layerIndex)
+    {
+        _effectFired = false;
+    }
+
+    public override void OnStateUpdate(
+        Animator animator,
+        AnimatorStateInfo stateInfo,
+        int layerIndex)
+    {
+        if (_effectFired) return;
+
+        if (stateInfo.normalizedTime <  _effectTiming)
+        {
+            return;
+        }
+
+        _effectFired = true;
+
+        if (animator.TryGetComponent(
+            out IEnemyAnimationController controller))
+        {
+            controller.AnimEvent_AttackEffect();
+        }
+    }
+}

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackEffectSMB.cs
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackEffectSMB.cs
@@ -2,12 +2,6 @@ using UnityEngine;
 
 public class EnemyAttackEffectSMB : StateMachineBehaviour
 {
-    [Header("Effect Timing (normalized 0-1)")]
-    [SerializeField,Range(0f, 1f)]
-    private float _effectTiming = 0.2f;
-
-    private bool _effectFired; 
-
     public override void OnStateEnter (Animator animator, AnimatorStateInfo stateInfo,int layerIndex)
     {
         _effectFired = false;
@@ -33,4 +27,10 @@ public class EnemyAttackEffectSMB : StateMachineBehaviour
             controller.AnimEvent_AttackEffect();
         }
     }
+
+    [Header("Effect Timing (normalized 0-1)")]
+    [SerializeField, Range(0f, 1f)]
+    private float _effectTiming = 0.2f;
+
+    private bool _effectFired;
 }

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackEffectSMB.cs.meta
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackEffectSMB.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 824d8ee1413e99946a75ca97238d8699

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackSMB.cs
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackSMB.cs
@@ -10,6 +10,12 @@ public class EnemyAttackSMB : StateMachineBehaviour
     public override void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         _attackHitFired = false;
+        _weaponSwingFired = false;
+
+        if (animator.TryGetComponent(out IEnemyAnimationController controller))
+        {
+            controller.AnimEvent_AttackStart();
+        }
     }
 
     public override void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
@@ -24,6 +30,17 @@ public class EnemyAttackSMB : StateMachineBehaviour
             if (animator.TryGetComponent(out IEnemyAnimationController controller))
                 controller.AnimEvent_AttackHit();
         }
+
+        //武器スイングSE
+        if (!_attackHitFired &&currentTime >= _attackHitTime)
+        {
+            _attackHitFired = true;
+
+            if (animator.TryGetComponent(out IEnemyAnimationController controller))
+            {
+                controller.AnimEvent_AttackHit();
+            }
+        }
     }
 
     public override void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
@@ -36,5 +53,9 @@ public class EnemyAttackSMB : StateMachineBehaviour
     [Tooltip("攻撃ヒット判定を発火する秒数")]
     [SerializeField] private float _attackHitTime = 0.3f;
 
+    [SerializeField, Tooltip("武器のスイングするSEの発生タイミング")]
+    private float _weaponSwingTime = 0.633f;//MobEnemyは 0.633f Golemは0.6533f
+
     private bool _attackHitFired;
+    private bool _weaponSwingFired;
 }

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackSMB.cs
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackSMB.cs
@@ -21,25 +21,25 @@ public class EnemyAttackSMB : StateMachineBehaviour
     public override void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         if (animator.speed == 0f) return;
-        if (_attackHitFired) return;
-
         float currentTime = stateInfo.normalizedTime * stateInfo.length;
+        float normalizedTime = stateInfo.normalizedTime % 1f;
+        // 武器スイングSE
+        if (!_weaponSwingFired && normalizedTime >= _weaponSwingTime)
+        {
+            _weaponSwingFired = true;
+
+            if (animator.TryGetComponent(out IEnemyAnimationController controller))
+            {
+                controller.AnimEvent_WeaponSwing();
+            }
+        }
+
+        if (_attackHitFired) return;
         if (currentTime >= _attackHitTime)
         {
             _attackHitFired = true;
             if (animator.TryGetComponent(out IEnemyAnimationController controller))
                 controller.AnimEvent_AttackHit();
-        }
-
-        //武器スイングSE
-        if (!_attackHitFired &&currentTime >= _attackHitTime)
-        {
-            _attackHitFired = true;
-
-            if (animator.TryGetComponent(out IEnemyAnimationController controller))
-            {
-                controller.AnimEvent_AttackHit();
-            }
         }
     }
 
@@ -53,8 +53,8 @@ public class EnemyAttackSMB : StateMachineBehaviour
     [Tooltip("攻撃ヒット判定を発火する秒数")]
     [SerializeField] private float _attackHitTime = 0.3f;
 
-    [SerializeField, Tooltip("武器のスイングするSEの発生タイミング")]
-    private float _weaponSwingTime = 0.633f;//MobEnemyは 0.633f Golemは0.6533f
+    [SerializeField, Tooltip("武器を振るSEの発火タイミング(秒数)")]
+    private float _weaponSwingTime = 0.633f;//MobEnemyは 0.32f Golemは0.6533f
 
     private bool _attackHitFired;
     private bool _weaponSwingFired;

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyBarkSMB.cs
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyBarkSMB.cs
@@ -6,9 +6,19 @@ using UnityEngine;
 /// </summary>
 public class EnemyBarkSMB : StateMachineBehaviour
 {
+    public override void OnStateEnter(Animator animator,AnimatorStateInfo stateInfo,int layerIndex)
+    {
+        if (animator.TryGetComponent(out IEnemyAnimationController controller))
+        {
+            controller.AnimEvent_BarkStart();
+        }
+    }
+
     public override void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         if (animator.TryGetComponent(out IEnemyAnimationController controller))
+        {
             controller.AnimEvent_BarkEnd();
+        }
     }
 }

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyDownSMB.cs
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyDownSMB.cs
@@ -26,6 +26,7 @@ public class EnemyDownSMB : StateMachineBehaviour
             if (animator.TryGetComponent(out IEnemyAnimationController c))
             {
                 c.AnimEvent_DownEnd();
+                c.AnimEvent_DownStart();
             }
         }
     }

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyDownSMB.cs
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyDownSMB.cs
@@ -26,7 +26,6 @@ public class EnemyDownSMB : StateMachineBehaviour
             if (animator.TryGetComponent(out IEnemyAnimationController c))
             {
                 c.AnimEvent_DownEnd();
-                c.AnimEvent_DownStart();
             }
         }
     }

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyDownStartSMB.cs
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyDownStartSMB.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+public class EnemyDownStartSMB : StateMachineBehaviour
+{
+    public override void OnStateEnter(
+        Animator animator,
+        AnimatorStateInfo stateInfo,
+        int layerIndex)
+    {
+        if (animator.TryGetComponent(out IEnemyAnimationController c))
+        {
+            c.AnimEvent_DownStart();
+        }
+    }
+}

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyDownStartSMB.cs.meta
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyDownStartSMB.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 84d2d9bed8e38d744a2cc366d7206454

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyFootstepSMB.cs
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyFootstepSMB.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+
+public class EnemyFootstepSMB : StateMachineBehaviour
+{ 
+    public override void OnStateEnter(
+       Animator animator,
+       AnimatorStateInfo stateInfo,
+       int layerIndex)
+    {
+        _leftFired = false;
+        _rightFired = false;
+        // 現在のループ数の記録
+        _loopCount = Mathf.FloorToInt(stateInfo.normalizedTime);
+    }
+
+    public override void OnStateUpdate(
+        Animator animator,
+        AnimatorStateInfo stateInfo,
+        int layerIndex)
+    {
+        if (animator.speed == 0f) return;
+
+        int currentLoop = Mathf.FloorToInt(stateInfo.normalizedTime);
+
+        if (currentLoop != _loopCount)
+        {
+            _loopCount = currentLoop;
+
+            _leftFired = false;
+            _rightFired = false;
+        }
+
+        float normalizedTime = stateInfo.normalizedTime % 1f;
+
+        // 左足タイミング
+        if (!_leftFired && normalizedTime >= _leftFootTime)
+        {
+            _leftFired = true;
+
+            if (animator.TryGetComponent(out IEnemyAnimationController controller))
+            {
+                controller.AnimEvent_Footstep();
+            }
+        }
+
+        // 右足タイミング
+        if (!_rightFired &&
+            normalizedTime >= _rightFootTime)
+        {
+            _rightFired = true;
+
+            if (animator.TryGetComponent(out IEnemyAnimationController controller))
+            {
+                controller.AnimEvent_Footstep();
+            }
+        }
+    }
+
+    [SerializeField] private float _leftFootTime = 0.1f;
+
+    [SerializeField] private float _rightFootTime = 0.557f;
+
+    private bool _leftFired;
+    private bool _rightFired;
+    private int _loopCount;
+}

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyFootstepSMB.cs.meta
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyFootstepSMB.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2362b8904c559b741a56af2c58f4bc8b

--- a/Assets/Scripts/Enemy/Mob/Sound.meta
+++ b/Assets/Scripts/Enemy/Mob/Sound.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 07aa6776fa30f624388ebfd669ba107e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs
+++ b/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs
@@ -55,10 +55,10 @@ public class EnemySoundHandler : MonoBehaviour
                     SoundCueNames.Common.EnemyFinisher,
                     CueSheetType.Common);
 
-                //Sound.PlaySE(
-                //    gameObject,
-                //    SoundCueNames.Enemy.StoneGolemDeathVoice,
-                //    CueSheetType.Golem);
+                Sound.PlaySE(
+                    gameObject,
+                    SoundCueNames.Enemy.StoneGolemDeathVoice,
+                    CueSheetType.Golem);
                 break;
 
         }
@@ -70,7 +70,7 @@ public class EnemySoundHandler : MonoBehaviour
         switch (_enemy.EnemyType)
         {
             case EnemyType.Draugr:
-                //Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrDamageVoice, CueSheetType.Mob);
+                Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrDamageVoice, CueSheetType.Mob);
                 break;
         }
     }
@@ -80,11 +80,11 @@ public class EnemySoundHandler : MonoBehaviour
         switch (_enemy.EnemyType)
         {
             case EnemyType.Draugr:
-                //Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrAttackVoice, CueSheetType.Mob);
-                //Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrWeaponSwing, CueSheetType.Mob);
+                Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrAttackVoice, CueSheetType.Mob);
+                Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrWeaponSwing, CueSheetType.Mob);
                 break;
             case EnemyType.StoneGolem:
-                //Sound.PlaySE(gameObject, SoundCueNames.Enemy.StoneGolemFootStomp, CueSheetType.Golem);
+                Sound.PlaySE(gameObject, SoundCueNames.Enemy.StoneGolemFootStomp, CueSheetType.Golem);
                 break;
         }
     }
@@ -94,17 +94,17 @@ public class EnemySoundHandler : MonoBehaviour
         switch (_enemy.EnemyType)
         {
             case EnemyType.Draugr:
-                //Sound.PlaySE(
-                //    gameObject,
-                //    SoundCueNames.Enemy.DraugrBark,
-                //    CueSheetType.Mob);
+                Sound.PlaySE(
+                    gameObject,
+                    SoundCueNames.Enemy.DraugrBark,
+                    CueSheetType.Mob);
                 break;
 
             case EnemyType.StoneGolem:
-                //Sound.PlaySE(
-                //    gameObject,
-                //    SoundCueNames.Enemy.StoneGolemBark,
-                //    CueSheetType.Golem);
+                Sound.PlaySE(
+                gameObject,
+                    SoundCueNames.Enemy.StoneGolemBark,
+                    CueSheetType.Golem);
                 break;
         }
     }
@@ -112,10 +112,10 @@ public class EnemySoundHandler : MonoBehaviour
     private void HandleDown()
     {
         if (_enemy.EnemyType != EnemyType.StoneGolem) return;
-        //Sound.PlaySE(
-        //    gameObject,
-        //    SoundCueNames.Enemy.StoneGolemDownVoice,
-        //    CueSheetType.Golem);
+        Sound.PlaySE(
+            gameObject,
+            SoundCueNames.Enemy.StoneGolemDownVoice,
+            CueSheetType.Golem);
     }
 
     private void HandleFootstep()
@@ -123,10 +123,10 @@ public class EnemySoundHandler : MonoBehaviour
         switch (_enemy.EnemyType)
         {
             case EnemyType.StoneGolem:
-                //Sound.PlaySE(
-                //    gameObject,
-                //    SoundCueNames.Enemy.StoneGolemFootstep,
-                //    CueSheetType.Golem);
+                Sound.PlaySE(
+                    gameObject,
+                    SoundCueNames.Enemy.StoneGolemFootstep,
+                    CueSheetType.Golem);
                 break;
         }
     }

--- a/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs
+++ b/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs
@@ -8,7 +8,6 @@ public class EnemySoundHandler : MonoBehaviour
     {
         _enemy = enemy;
 
-        _enemy.OnArmorBroken += HandleArmorBreak;
         _enemy.OnDead += HandleDead;
         _enemy.OnDamaged += HandleDamaged;
         _enemy.EnemyAnimator.OnAttackEffect += HandleAttack;
@@ -21,7 +20,6 @@ public class EnemySoundHandler : MonoBehaviour
     {
         if (_enemy == null) return;
 
-        _enemy.OnArmorBroken -= HandleArmorBreak;
         _enemy.OnDead -= HandleDead;
         _enemy.OnDamaged -= HandleDamaged;
         _enemy.EnemyAnimator.OnAttackEffect -= HandleAttack;
@@ -30,31 +28,12 @@ public class EnemySoundHandler : MonoBehaviour
         _enemy.EnemyAnimator.OnBarkStart -= HandleBark;
     }
 
-    private void HandleArmorBreak(IEnemy _)
-    {
-        Sound.PlaySE(
-            gameObject,
-            SoundCueNames.Common.ArmorBreak,
-            CueSheetType.Common);
-    }
-
     private void HandleDead(IEnemy _)
     {
+       
         switch (_enemy.EnemyType)
         {
-            case EnemyType.Draugr:
-                Sound.PlaySE(
-                    gameObject,
-                    SoundCueNames.Common.EnemyFinisher,
-                    CueSheetType.Common);
-                break;
-
             case EnemyType.StoneGolem:
-                Sound.PlaySE(
-                    gameObject,
-                    SoundCueNames.Common.EnemyFinisher,
-                    CueSheetType.Common);
-
                 Sound.PlaySE(
                     gameObject,
                     SoundCueNames.Enemy.StoneGolemDeathVoice,
@@ -67,6 +46,7 @@ public class EnemySoundHandler : MonoBehaviour
 
     private void HandleDamaged(IEnemy _)
     {
+        Debug.Log("Dameg SE triggered");
         switch (_enemy.EnemyType)
         {
             case EnemyType.Draugr:
@@ -77,6 +57,7 @@ public class EnemySoundHandler : MonoBehaviour
 
     private void HandleAttack()
     {
+        Debug.Log("Attack SE triggered");
         switch (_enemy.EnemyType)
         {
             case EnemyType.Draugr:
@@ -91,9 +72,11 @@ public class EnemySoundHandler : MonoBehaviour
 
     private void HandleBark()
     {
+        Debug.Log("Bark SE triggered");
         switch (_enemy.EnemyType)
         {
             case EnemyType.Draugr:
+                Debug.Log("Bark SE triggered2");
                 Sound.PlaySE(
                     gameObject,
                     SoundCueNames.Enemy.DraugrBark,
@@ -111,6 +94,7 @@ public class EnemySoundHandler : MonoBehaviour
 
     private void HandleDown()
     {
+        Debug.Log("Down SE triggered");
         if (_enemy.EnemyType != EnemyType.StoneGolem) return;
         Sound.PlaySE(
             gameObject,
@@ -120,6 +104,7 @@ public class EnemySoundHandler : MonoBehaviour
 
     private void HandleFootstep()
     {
+        Debug.Log("Step SE triggered");
         switch (_enemy.EnemyType)
         {
             case EnemyType.StoneGolem:

--- a/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs
+++ b/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs
@@ -55,10 +55,10 @@ public class EnemySoundHandler : MonoBehaviour
                     SoundCueNames.Common.EnemyFinisher,
                     CueSheetType.Common);
 
-                Sound.PlaySE(
-                    gameObject,
-                    SoundCueNames.Enemy.StoneGolemDeathVoice,
-                    CueSheetType.Golem);
+                //Sound.PlaySE(
+                //    gameObject,
+                //    SoundCueNames.Enemy.StoneGolemDeathVoice,
+                //    CueSheetType.Golem);
                 break;
 
         }
@@ -70,7 +70,7 @@ public class EnemySoundHandler : MonoBehaviour
         switch (_enemy.EnemyType)
         {
             case EnemyType.Draugr:
-                Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrDamageVoice, CueSheetType.Mob);
+                //Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrDamageVoice, CueSheetType.Mob);
                 break;
         }
     }
@@ -80,11 +80,11 @@ public class EnemySoundHandler : MonoBehaviour
         switch (_enemy.EnemyType)
         {
             case EnemyType.Draugr:
-                Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrAttackVoice, CueSheetType.Mob);
-                Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrWeaponSwing, CueSheetType.Mob);
+                //Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrAttackVoice, CueSheetType.Mob);
+                //Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrWeaponSwing, CueSheetType.Mob);
                 break;
             case EnemyType.StoneGolem:
-                Sound.PlaySE(gameObject, SoundCueNames.Enemy.StoneGolemFootStomp, CueSheetType.Golem);
+                //Sound.PlaySE(gameObject, SoundCueNames.Enemy.StoneGolemFootStomp, CueSheetType.Golem);
                 break;
         }
     }
@@ -94,17 +94,17 @@ public class EnemySoundHandler : MonoBehaviour
         switch (_enemy.EnemyType)
         {
             case EnemyType.Draugr:
-                Sound.PlaySE(
-                    gameObject,
-                    SoundCueNames.Enemy.DraugrBark,
-                    CueSheetType.Mob);
+                //Sound.PlaySE(
+                //    gameObject,
+                //    SoundCueNames.Enemy.DraugrBark,
+                //    CueSheetType.Mob);
                 break;
 
             case EnemyType.StoneGolem:
-                Sound.PlaySE(
-                    gameObject,
-                    SoundCueNames.Enemy.StoneGolemBark,
-                    CueSheetType.Golem);
+                //Sound.PlaySE(
+                //    gameObject,
+                //    SoundCueNames.Enemy.StoneGolemBark,
+                //    CueSheetType.Golem);
                 break;
         }
     }
@@ -112,10 +112,10 @@ public class EnemySoundHandler : MonoBehaviour
     private void HandleDown()
     {
         if (_enemy.EnemyType != EnemyType.StoneGolem) return;
-        Sound.PlaySE(
-            gameObject,
-            SoundCueNames.Enemy.StoneGolemDownVoice,
-            CueSheetType.Golem);
+        //Sound.PlaySE(
+        //    gameObject,
+        //    SoundCueNames.Enemy.StoneGolemDownVoice,
+        //    CueSheetType.Golem);
     }
 
     private void HandleFootstep()
@@ -123,10 +123,10 @@ public class EnemySoundHandler : MonoBehaviour
         switch (_enemy.EnemyType)
         {
             case EnemyType.StoneGolem:
-                Sound.PlaySE(
-                    gameObject,
-                    SoundCueNames.Enemy.StoneGolemFootstep,
-                    CueSheetType.Golem);
+                //Sound.PlaySE(
+                //    gameObject,
+                //    SoundCueNames.Enemy.StoneGolemFootstep,
+                //    CueSheetType.Golem);
                 break;
         }
     }

--- a/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs
+++ b/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs
@@ -2,19 +2,20 @@ using UnityEngine;
 
 public class EnemySoundHandler : MonoBehaviour
 {
-    private Enemy _enemy;
-
     public void Init(Enemy enemy)
     {
         _enemy = enemy;
 
         _enemy.OnDead += HandleDead;
         _enemy.OnDamaged += HandleDamaged;
-        _enemy.EnemyAnimator.OnAttackEffect += HandleAttack;
+        _enemy.EnemyAnimator.OnAttackStart += HandleAttack;
         _enemy.EnemyAnimator.OnDownStart += HandleDown;
         _enemy.EnemyAnimator.OnFootstep += HandleFootstep;
         _enemy.EnemyAnimator.OnBarkStart += HandleBark;
+        _enemy.EnemyAnimator.OnWeaponSwing += HandleWeaponSwing;
     }
+
+    private Enemy _enemy;
 
     private void OnDestroy()
     {
@@ -22,10 +23,11 @@ public class EnemySoundHandler : MonoBehaviour
 
         _enemy.OnDead -= HandleDead;
         _enemy.OnDamaged -= HandleDamaged;
-        _enemy.EnemyAnimator.OnAttackEffect -= HandleAttack;
+        _enemy.EnemyAnimator.OnAttackStart -= HandleAttack;
         _enemy.EnemyAnimator.OnDownStart -= HandleDown;
         _enemy.EnemyAnimator.OnFootstep -= HandleFootstep;
         _enemy.EnemyAnimator.OnBarkStart -= HandleBark;
+        _enemy.EnemyAnimator.OnWeaponSwing -= HandleWeaponSwing;
     }
 
     private void HandleDead(IEnemy _)
@@ -62,10 +64,26 @@ public class EnemySoundHandler : MonoBehaviour
         {
             case EnemyType.Draugr:
                 Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrAttackVoice, CueSheetType.Mob);
-                Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrWeaponSwing, CueSheetType.Mob);
                 break;
+        }
+    }
+
+    private void HandleWeaponSwing()
+    {
+        switch (_enemy.EnemyType)
+        {
+            case EnemyType.Draugr:
+                Sound.PlaySE(
+                    gameObject,
+                    SoundCueNames.Enemy.DraugrWeaponSwing,
+                    CueSheetType.Mob);
+                break;
+
             case EnemyType.StoneGolem:
-                Sound.PlaySE(gameObject, SoundCueNames.Enemy.StoneGolemFootStomp, CueSheetType.Golem);
+                Sound.PlaySE(
+                    gameObject,
+                    SoundCueNames.Enemy.StoneGolemGroundStomp,
+                    CueSheetType.Golem);
                 break;
         }
     }

--- a/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs
+++ b/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs
@@ -1,0 +1,125 @@
+using UnityEngine;
+
+public class EnemySoundHandler : MonoBehaviour
+{
+    private Enemy _enemy;
+
+    public void Init(Enemy enemy)
+    {
+        _enemy = enemy;
+
+        _enemy.OnArmorBroken += HandleArmorBreak;
+        _enemy.OnDead += HandleDead;
+        _enemy.OnDamaged += HandleDamaged;
+        _enemy.EnemyAnimator.OnAttackEffect += HandleAttack;
+        _enemy.EnemyAnimator.OnDownStart += HandleDown;
+        _enemy.EnemyAnimator.OnFootstep += HandleFootstep;
+        _enemy.EnemyAnimator.OnBarkStart += HandleBark;
+    }
+
+    private void OnDestroy()
+    {
+        if (_enemy == null) return;
+
+        _enemy.OnArmorBroken -= HandleArmorBreak;
+        _enemy.OnDead -= HandleDead;
+        _enemy.OnDamaged -= HandleDamaged;
+        _enemy.EnemyAnimator.OnAttackEffect -= HandleAttack;
+        _enemy.EnemyAnimator.OnDownStart -= HandleDown;
+        _enemy.EnemyAnimator.OnFootstep -= HandleFootstep;
+        _enemy.EnemyAnimator.OnBarkStart -= HandleBark;
+    }
+
+    private void HandleArmorBreak(IEnemy _)
+    {
+        Sound.PlaySE(
+            gameObject,
+            SoundCueNames.Common.ArmorBreak,
+            CueSheetType.Common);
+    }
+
+    private void HandleDead(IEnemy _)
+    {
+        switch (_enemy.EnemyType)
+        {
+            case EnemyType.Draugr:
+                Sound.PlaySE(
+                    gameObject,
+                    SoundCueNames.Common.EnemyFinisher,
+                    CueSheetType.Common);
+                break;
+
+            case EnemyType.StoneGolem:
+
+                break;
+
+        }
+
+    }
+
+    private void HandleDamaged(IEnemy _)
+    {
+        switch (_enemy.EnemyType)
+        {
+            case EnemyType.Draugr:
+                //Sound.PlaySE(gameObject, SoundCueNames.Enemy., CueSheetType.Enemy);
+                break;
+            case EnemyType.StoneGolem:
+                break;
+        }
+    }
+
+    private void HandleAttack()
+    {
+        switch (_enemy.EnemyType)
+        {
+            case EnemyType.Draugr:
+                break;
+            case EnemyType.StoneGolem:
+                break;
+        }
+    }
+
+    private void HandleBark()
+    {
+        switch (_enemy.EnemyType)
+        {
+            case EnemyType.Draugr:
+                //Sound.PlaySE(
+                //    gameObject,
+                //    SoundCueNames.Enemy.DraugrBark,
+                //    CueSheetType.Mob);
+                break;
+
+            case EnemyType.StoneGolem:
+                //Sound.PlaySE(
+                //    gameObject,
+                //    SoundCueNames.Enemy.StoneGolemBark,
+                //    CueSheetType.Golem);
+                break;
+        }
+    }
+
+    private void HandleDown()
+    {
+        //Sound.PlaySE(
+        //    gameObject,
+        //    SoundCueNames.Enemy.StoneGolemDownVoice,
+        //    CueSheetType.Golem);
+    }
+
+    private void HandleFootstep()
+    {
+        switch (_enemy.EnemyType)
+        {
+            case EnemyType.StoneGolem:
+                //Sound.PlaySE(
+                //    gameObject,
+                //    SoundCueNames.Enemy.StoneGolemFootstep,
+                //    CueSheetType.Golem);
+                break;
+        }
+    }
+}
+
+//switchが多いく拡張がしずらいので後々、Profileのようなものを作ってEnemyごとに持たせるのがいいと思う。

--- a/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs
+++ b/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs
@@ -50,7 +50,15 @@ public class EnemySoundHandler : MonoBehaviour
                 break;
 
             case EnemyType.StoneGolem:
+                Sound.PlaySE(
+                    gameObject,
+                    SoundCueNames.Common.EnemyFinisher,
+                    CueSheetType.Common);
 
+                Sound.PlaySE(
+                    gameObject,
+                    SoundCueNames.Enemy.StoneGolemDeathVoice,
+                    CueSheetType.Golem);
                 break;
 
         }
@@ -62,9 +70,7 @@ public class EnemySoundHandler : MonoBehaviour
         switch (_enemy.EnemyType)
         {
             case EnemyType.Draugr:
-                //Sound.PlaySE(gameObject, SoundCueNames.Enemy., CueSheetType.Enemy);
-                break;
-            case EnemyType.StoneGolem:
+                Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrDamageVoice, CueSheetType.Mob);
                 break;
         }
     }
@@ -74,8 +80,11 @@ public class EnemySoundHandler : MonoBehaviour
         switch (_enemy.EnemyType)
         {
             case EnemyType.Draugr:
+                Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrAttackVoice, CueSheetType.Mob);
+                Sound.PlaySE(gameObject, SoundCueNames.Enemy.DraugrWeaponSwing, CueSheetType.Mob);
                 break;
             case EnemyType.StoneGolem:
+                Sound.PlaySE(gameObject, SoundCueNames.Enemy.StoneGolemFootStomp, CueSheetType.Golem);
                 break;
         }
     }
@@ -85,27 +94,28 @@ public class EnemySoundHandler : MonoBehaviour
         switch (_enemy.EnemyType)
         {
             case EnemyType.Draugr:
-                //Sound.PlaySE(
-                //    gameObject,
-                //    SoundCueNames.Enemy.DraugrBark,
-                //    CueSheetType.Mob);
+                Sound.PlaySE(
+                    gameObject,
+                    SoundCueNames.Enemy.DraugrBark,
+                    CueSheetType.Mob);
                 break;
 
             case EnemyType.StoneGolem:
-                //Sound.PlaySE(
-                //    gameObject,
-                //    SoundCueNames.Enemy.StoneGolemBark,
-                //    CueSheetType.Golem);
+                Sound.PlaySE(
+                    gameObject,
+                    SoundCueNames.Enemy.StoneGolemBark,
+                    CueSheetType.Golem);
                 break;
         }
     }
 
     private void HandleDown()
     {
-        //Sound.PlaySE(
-        //    gameObject,
-        //    SoundCueNames.Enemy.StoneGolemDownVoice,
-        //    CueSheetType.Golem);
+        if (_enemy.EnemyType != EnemyType.StoneGolem) return;
+        Sound.PlaySE(
+            gameObject,
+            SoundCueNames.Enemy.StoneGolemDownVoice,
+            CueSheetType.Golem);
     }
 
     private void HandleFootstep()
@@ -113,10 +123,10 @@ public class EnemySoundHandler : MonoBehaviour
         switch (_enemy.EnemyType)
         {
             case EnemyType.StoneGolem:
-                //Sound.PlaySE(
-                //    gameObject,
-                //    SoundCueNames.Enemy.StoneGolemFootstep,
-                //    CueSheetType.Golem);
+                Sound.PlaySE(
+                    gameObject,
+                    SoundCueNames.Enemy.StoneGolemFootstep,
+                    CueSheetType.Golem);
                 break;
         }
     }

--- a/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs.meta
+++ b/Assets/Scripts/Enemy/Mob/Sound/EnemySoundHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3228565db4b453e42b723817d49cbe9b

--- a/Assets/Scripts/Interface/IEnemyAnimationController.cs
+++ b/Assets/Scripts/Interface/IEnemyAnimationController.cs
@@ -30,4 +30,9 @@ public interface IEnemyAnimationController
 
     /// <summary>アタックエフェクトの再生タイミング通知</summary>
     public void AnimEvent_AttackEffect();
+
+    public void AnimEvent_BarkStart();
+
+    /// <summary>攻撃開始の通知</summary>
+    public void AnimEvent_AttackStart();
 }

--- a/Assets/Scripts/Interface/IEnemyAnimationController.cs
+++ b/Assets/Scripts/Interface/IEnemyAnimationController.cs
@@ -25,6 +25,8 @@ public interface IEnemyAnimationController
 
     /// <summary>ダウンアニメーション終了の通知 </summary>
     public void AnimEvent_DownEnd();
+    /// <summary>ダウンアニメーションの開始</summary>
+    public void AnimEvent_DownStart();
 
     /// <summary>アタックエフェクトの再生タイミング通知</summary>
     public void AnimEvent_AttackEffect();

--- a/Assets/Scripts/Interface/IEnemyAnimationController.cs
+++ b/Assets/Scripts/Interface/IEnemyAnimationController.cs
@@ -25,4 +25,7 @@ public interface IEnemyAnimationController
 
     /// <summary>ダウンアニメーション終了の通知 </summary>
     public void AnimEvent_DownEnd();
+
+    /// <summary>アタックエフェクトの再生タイミング通知</summary>
+    public void AnimEvent_AttackEffect();
 }

--- a/Assets/Scripts/Interface/IEnemyAnimationController.cs
+++ b/Assets/Scripts/Interface/IEnemyAnimationController.cs
@@ -35,4 +35,10 @@ public interface IEnemyAnimationController
 
     /// <summary>攻撃開始の通知</summary>
     public void AnimEvent_AttackStart();
+
+    /// <summary>足音イベント</summary>
+    public void AnimEvent_Footstep();
+
+    /// <summary>武器スイングSEタイミング</summary>
+    public void AnimEvent_WeaponSwing();
 }

--- a/Assets/Scripts/Interface/IEnemyAnimator.cs
+++ b/Assets/Scripts/Interface/IEnemyAnimator.cs
@@ -27,6 +27,8 @@ public interface IEnemyAnimator
     public event Action OnFootstep;
     /// <summary>Bark開始イベント</summary>
     event Action OnBarkStart;
+    /// <summary>攻撃開始イベント</summary>
+    event Action OnAttackStart;
 
     /// <summary>移動速度を設定する（Idle / Move の切り替えに使用）</summary>
     public void SetSpeed(float speed);
@@ -68,6 +70,7 @@ public sealed class NullEnemyAnimator : IEnemyAnimator
     public event Action OnAttackEffect;
     public event Action OnFootstep;
     public event Action OnBarkStart;
+    public event Action OnAttackStart;
 #pragma warning restore CS0067
 
     public void SetSpeed(float speed) { }

--- a/Assets/Scripts/Interface/IEnemyAnimator.cs
+++ b/Assets/Scripts/Interface/IEnemyAnimator.cs
@@ -29,6 +29,8 @@ public interface IEnemyAnimator
     event Action OnBarkStart;
     /// <summary>攻撃開始イベント</summary>
     event Action OnAttackStart;
+    /// <summary>武器スイングSEイベント</summary>
+    public event Action OnWeaponSwing;
 
     /// <summary>移動速度を設定する（Idle / Move の切り替えに使用）</summary>
     public void SetSpeed(float speed);
@@ -71,6 +73,7 @@ public sealed class NullEnemyAnimator : IEnemyAnimator
     public event Action OnFootstep;
     public event Action OnBarkStart;
     public event Action OnAttackStart;
+    public event Action OnWeaponSwing;
 #pragma warning restore CS0067
 
     public void SetSpeed(float speed) { }

--- a/Assets/Scripts/Interface/IEnemyAnimator.cs
+++ b/Assets/Scripts/Interface/IEnemyAnimator.cs
@@ -19,6 +19,14 @@ public interface IEnemyAnimator
     public event Action OnDeadEnd;
     /// <summary>ダウンアニメーション終了のイベント </summary>
     public event Action OnDownEnd;
+    /// <summary>ダウン開始イベント</summary>
+    public event Action OnDownStart;
+    /// <summary>攻撃エフェクト・SE発火イベント</summary>
+    public event Action OnAttackEffect;
+    /// <summary>歩行時のイベント</summary>
+    public event Action OnFootstep;
+    /// <summary>Bark開始イベント</summary>
+    event Action OnBarkStart;
 
     /// <summary>移動速度を設定する（Idle / Move の切り替えに使用）</summary>
     public void SetSpeed(float speed);
@@ -56,6 +64,10 @@ public sealed class NullEnemyAnimator : IEnemyAnimator
     public event Action OnKnockbackEnd;
     public event Action OnDeadEnd;
     public event Action OnDownEnd;
+    public event Action OnDownStart;
+    public event Action OnAttackEffect;
+    public event Action OnFootstep;
+    public event Action OnBarkStart;
 #pragma warning restore CS0067
 
     public void SetSpeed(float speed) { }

--- a/Assets/Scripts/Sound/CueSheetPathHolder.cs
+++ b/Assets/Scripts/Sound/CueSheetPathHolder.cs
@@ -12,6 +12,8 @@ public class CueSheetPathHolder
         CueSheetPathDict.Add(CueSheetType.Enemy, "Enemy_SE");
         CueSheetPathDict.Add(CueSheetType.Common, "Common_SE");
         CueSheetPathDict.Add(CueSheetType.InGameBGM, "InGame_BGM");
+        CueSheetPathDict.Add(CueSheetType.Golem, "Golem_SE");
+        CueSheetPathDict.Add(CueSheetType.Mob, "Mob_SE");
     }
 }
 
@@ -23,4 +25,6 @@ public enum CueSheetType
     Enemy,
     Common,
     InGameBGM,
+    Golem,
+    Mob
 }

--- a/Assets/Scripts/Sound/CueSheetPathHolder.cs
+++ b/Assets/Scripts/Sound/CueSheetPathHolder.cs
@@ -12,8 +12,6 @@ public class CueSheetPathHolder
         CueSheetPathDict.Add(CueSheetType.Enemy, "Enemy_SE");
         CueSheetPathDict.Add(CueSheetType.Common, "Common_SE");
         CueSheetPathDict.Add(CueSheetType.InGameBGM, "InGame_BGM");
-        CueSheetPathDict.Add(CueSheetType.Golem, "Golem_SE");
-        CueSheetPathDict.Add(CueSheetType.Mob, "Mob_SE");
     }
 }
 

--- a/Assets/Scripts/Sound/CueSheetPathHolder.cs
+++ b/Assets/Scripts/Sound/CueSheetPathHolder.cs
@@ -23,6 +23,4 @@ public enum CueSheetType
     Enemy,
     Common,
     InGameBGM,
-    Golem,
-    Mob
 }

--- a/Assets/Scripts/Sound/SoundCueNames.cs
+++ b/Assets/Scripts/Sound/SoundCueNames.cs
@@ -81,7 +81,7 @@ public static class SoundCueNames
         public const string DraugrDamageVoice = "DraugrDamageVoice";
 
         /// <summary>ストーンゴーレム地面踏みつけ</summary>
-        public const string StoneGolemFootStomp = "StoneGolemGroundStomp";
+        public const string StoneGolemFootStomp = "StoneGolemFootStomp";
 
         /// <summary>ストーンゴーレムの足音</summary>
         public const string StoneGolemFootstep = "StoneGolemFootstep";

--- a/Assets/Scripts/Sound/SoundCueNames.cs
+++ b/Assets/Scripts/Sound/SoundCueNames.cs
@@ -47,13 +47,11 @@ public static class SoundCueNames
         public const string DraugrAttackVoice = "DraugrAttackVoice";
         public const string DraugrBark = "DraugrBark";
         public const string DraugrDamageVoice = "DraugrDamageVoice";
-        public const string StoneGolemFootStomp = "StoneGolemFootStomp";
+        public const string StoneGolemGroundStomp = "StoneGolemGroundStomp";
         public const string StoneGolemFootstep = "StoneGolemFootstep";
         public const string StoneGolemBark = "StoneGolemBark";
         public const string StoneGolemDownVoice = "StoneGolemDownVoice";
         public const string StoneGolemDeathVoice = "StoneGolemDeathVoice";
-
-        public const string StoneGolemGroundStomp = StoneGolemFootStomp;
     }
 
     public static class Boss

--- a/Assets/Scripts/Sound/SoundCueNames.cs
+++ b/Assets/Scripts/Sound/SoundCueNames.cs
@@ -71,8 +71,29 @@ public static class SoundCueNames
         /// <summary>ドラウグル武器振り</summary>
         public const string DraugrWeaponSwing = "DraugrWeaponSwing";
 
+        /// <summary>ドラウグル攻撃ボイス</summary>
+        public const string DraugrAttackVoice = "DraugrAttackVoice";
+
+        /// <summary>ドラウグル威嚇ボイス</summary>
+        public const string DraugrBark = "DraugrBark";
+
+        /// <summary>ドラウグル被弾ボイス</summary>
+        public const string DraugrDamageVoice = "DraugrDamageVoice";
+
         /// <summary>ストーンゴーレム地面踏みつけ</summary>
-        public const string StoneGolemGroundStomp = "StoneGolemGroundStomp";
+        public const string StoneGolemFootStomp = "StoneGolemGroundStomp";
+
+        /// <summary>ストーンゴーレムの足音</summary>
+        public const string StoneGolemFootstep = "StoneGolemFootstep";
+
+        /// <summary>ストーンゴーレムの威嚇</summary>
+        public const string StoneGolemBark = "StoneGolemBark";
+
+        /// <summary>ゴーレムダウンボイス</summary>
+        public const string StoneGolemDownVoice = "StoneGolemDownVoice";
+
+        /// <summary>ゴーレム死亡ボイス</summary>
+        public const string StoneGolemDeathVoice = "StoneGolemDeathVoice";
     }
 
     public static class BGM


### PR DESCRIPTION
鎧が壊れた後に鎧の耐久値が出なくなったため、改善

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 敵の攻撃、ダウン開始、足音、吠え開始などのアニメーション連動イベントが追加され、動きに合わせた演出がより細かく反映されるようになりました。
  * ゴーレム系の攻撃・ダウン・装甲復帰に合わせて、エフェクトや効果音の再生が強化されました。
* **Bug Fixes**
  * 攻撃開始・攻撃エフェクトの通知タイミングを整理し、演出が重複しにくくなりました。
  * 敵種別ごとの効果音再生が安定して行われるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->