### PR TITLE
カメラシェイクのバグ修正

### DIFF
--- a/Assets/Editor/AttackDataEditor.cs
+++ b/Assets/Editor/AttackDataEditor.cs
@@ -358,6 +358,12 @@ public class AttackDataEditor : Editor
         EditorGUILayout.LabelField("雷の追加ダメージ", EditorStyles.miniBoldLabel);
         EditorGUILayout.PropertyField(variantProp.FindPropertyRelative("_additionalLightningDamages"),
             new GUIContent("追加ダメージデータ"), true);
+        EditorGUILayout.Space(2);
+
+        // ---- カメラシェイクのデータ ----
+        EditorGUILayout.LabelField("カメラシェイクのデータ", EditorStyles.miniBoldLabel);
+        EditorGUILayout.PropertyField(variantProp.FindPropertyRelative("_cameraShakeData"),
+            new GUIContent("カメラシェイクのデータ"), true);
     }
 
     // =========================================================

--- a/Assets/Prefab/Camera/FreeLook Camera .prefab
+++ b/Assets/Prefab/Camera/FreeLook Camera .prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &961530871842838584
+--- !u!1 &396129334472459972
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,28 +8,28 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6166178355341034140}
-  - component: {fileID: 1622099667948176317}
-  - component: {fileID: 167389161284933562}
-  - component: {fileID: 3024584072184093913}
-  - component: {fileID: 6372492811266483842}
-  - component: {fileID: 1118617712252912988}
-  - component: {fileID: 6314859575784271827}
-  - component: {fileID: 2569257103208793588}
+  - component: {fileID: 6306472090074037060}
+  - component: {fileID: 1543495482878070137}
+  - component: {fileID: 4473104876080838834}
+  - component: {fileID: 2645919583080076796}
+  - component: {fileID: 3946644989644991223}
+  - component: {fileID: 5984953373226368970}
+  - component: {fileID: 4346747242968084537}
+  - component: {fileID: 4914881469722271051}
   m_Layer: 0
-  m_Name: FreeLook Camera
+  m_Name: 'FreeLook Camera '
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6166178355341034140
+--- !u!4 &6306472090074037060
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 961530871842838584}
+  m_GameObject: {fileID: 396129334472459972}
   serializedVersion: 2
   m_LocalRotation: {x: 0.104633205, y: -0.000000020438375, z: 0.0000000021503366, w: 0.9945109}
   m_LocalPosition: {x: 0, y: 2.25, z: -4}
@@ -38,13 +38,13 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1622099667948176317
+--- !u!114 &1543495482878070137
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 961530871842838584}
+  m_GameObject: {fileID: 396129334472459972}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
@@ -81,13 +81,13 @@ MonoBehaviour:
       BarrelClipping: 0.25
       Anamorphism: 0
   BlendHint: 0
---- !u!114 &167389161284933562
+--- !u!114 &4473104876080838834
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 961530871842838584}
+  m_GameObject: {fileID: 396129334472459972}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3b5d7c088409d9a40b7b09aa707777f8, type: 3}
@@ -144,13 +144,13 @@ MonoBehaviour:
       Wait: 1
       Time: 2
     Restrictions: 0
---- !u!114 &3024584072184093913
+--- !u!114 &2645919583080076796
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 961530871842838584}
+  m_GameObject: {fileID: 396129334472459972}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f38bda98361e1de48a4ca2bd86ea3c17, type: 3}
@@ -173,13 +173,13 @@ MonoBehaviour:
     Time: 0
     Smoothing: 0
     IgnoreY: 0
---- !u!114 &6372492811266483842
+--- !u!114 &3946644989644991223
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 961530871842838584}
+  m_GameObject: {fileID: 396129334472459972}
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a076c17fe76165e4f8ed21498b877bf9, type: 3}
@@ -190,25 +190,25 @@ MonoBehaviour:
   references:
     version: 2
     RefIds: []
---- !u!114 &1118617712252912988
+--- !u!114 &5984953373226368970
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 961530871842838584}
+  m_GameObject: {fileID: 396129334472459972}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 89875cdc57c54474a8a74efd9b2a3b5d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineInputAxisController
-  ScanRecursively: 1
+  ScanRecursively: 0
   SuppressInputWhileBlending: 1
   IgnoreTimeScale: 0
   m_ControllerManager:
     Controllers:
     - Name: Look Orbit X
-      Owner: {fileID: 167389161284933562}
+      Owner: {fileID: 4473104876080838834}
       Enabled: 1
       Input:
         InputAction: {fileID: -5630151704836100654, guid: 1d6e640e716dc4ff6989b73d02023f2b, type: 3}
@@ -221,7 +221,7 @@ MonoBehaviour:
         AccelTime: 0.2
         DecelTime: 0.2
     - Name: Look Orbit Y
-      Owner: {fileID: 167389161284933562}
+      Owner: {fileID: 4473104876080838834}
       Enabled: 1
       Input:
         InputAction: {fileID: -5630151704836100654, guid: 1d6e640e716dc4ff6989b73d02023f2b, type: 3}
@@ -234,7 +234,7 @@ MonoBehaviour:
         AccelTime: 0.2
         DecelTime: 0.2
     - Name: Orbit Scale
-      Owner: {fileID: 167389161284933562}
+      Owner: {fileID: 4473104876080838834}
       Enabled: 1
       Input:
         InputAction: {fileID: 5082991133974614888, guid: 1d6e640e716dc4ff6989b73d02023f2b, type: 3}
@@ -248,13 +248,13 @@ MonoBehaviour:
         DecelTime: 0
   PlayerIndex: -1
   AutoEnableInputs: 1
---- !u!114 &6314859575784271827
+--- !u!114 &4346747242968084537
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 961530871842838584}
+  m_GameObject: {fileID: 396129334472459972}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ca7de3aefa901374ba29464584a3109a, type: 3}
@@ -278,13 +278,13 @@ MonoBehaviour:
       m_Bits: 1
     MaximumRaycast: 10
     Damping: 0.5
---- !u!114 &2569257103208793588
+--- !u!114 &4914881469722271051
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 961530871842838584}
+  m_GameObject: {fileID: 396129334472459972}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 68bb026fafb42b14791938953eaace77, type: 3}
@@ -292,6 +292,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineBasicMultiChannelPerlin
   NoiseProfile: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4, type: 2}
   PivotOffset: {x: 0, y: 0, z: 0}
-  AmplitudeGain: 1
-  FrequencyGain: 1
+  AmplitudeGain: 0
+  FrequencyGain: 0
   m_NoiseOffsets: {x: 0, y: 0, z: 0}

--- a/Assets/Prefab/Camera/FreeLook Camera .prefab.meta
+++ b/Assets/Prefab/Camera/FreeLook Camera .prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 74267bc9deb974c4a80c2c11b7f619dd
+guid: 53598e6629a141a4885b7995e7822c27
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Prefab/Camera/LockOnCamera.prefab
+++ b/Assets/Prefab/Camera/LockOnCamera.prefab
@@ -1,0 +1,95 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3869294919606562035
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5468934978331119998}
+  - component: {fileID: 4417880117503769889}
+  - component: {fileID: 4569957180002623525}
+  m_Layer: 0
+  m_Name: LockOnCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5468934978331119998
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3869294919606562035}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.5, y: 1.75, z: -4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4417880117503769889
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3869294919606562035}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineCamera
+  Priority:
+    Enabled: 1
+    m_Value: 9
+  OutputChannel: 1
+  StandbyUpdate: 2
+  m_StreamingVersion: 20241001
+  m_LegacyPriority: 0
+  Target:
+    TrackingTarget: {fileID: 0}
+    LookAtTarget: {fileID: 0}
+    CustomLookAtTarget: 0
+  Lens:
+    FieldOfView: 50
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    PhysicalProperties:
+      GateFit: 2
+      SensorSize: {x: 21.946, y: 16.002}
+      LensShift: {x: 0, y: 0}
+      FocusDistance: 10
+      Iso: 200
+      ShutterSpeed: 0.005
+      Aperture: 16
+      BladeCount: 5
+      Curvature: {x: 2, y: 11}
+      BarrelClipping: 0.25
+      Anamorphism: 0
+  BlendHint: 0
+--- !u!114 &4569957180002623525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3869294919606562035}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68bb026fafb42b14791938953eaace77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineBasicMultiChannelPerlin
+  NoiseProfile: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4, type: 2}
+  PivotOffset: {x: 0, y: 0, z: 0}
+  AmplitudeGain: 0
+  FrequencyGain: 0
+  m_NoiseOffsets: {x: 0, y: 0, z: 0}

--- a/Assets/Prefab/Camera/LockOnCamera.prefab.meta
+++ b/Assets/Prefab/Camera/LockOnCamera.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a12584d220a7626498563601d8f7c9ec
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/TestScenes/PlayerTestScene.unity
+++ b/Assets/Scenes/TestScenes/PlayerTestScene.unity
@@ -2259,81 +2259,17 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &2117777433
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2117777435}
-  - component: {fileID: 2117777434}
-  m_Layer: 0
-  m_Name: LockOnCamera
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &2117777434
+--- !u!114 &2117777434 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4417880117503769889, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
+  m_PrefabInstance: {fileID: 8941122198464403569}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2117777433}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineCamera
-  Priority:
-    Enabled: 1
-    m_Value: 9
-  OutputChannel: 1
-  StandbyUpdate: 2
-  m_StreamingVersion: 20241001
-  m_LegacyPriority: 0
-  Target:
-    TrackingTarget: {fileID: 0}
-    LookAtTarget: {fileID: 0}
-    CustomLookAtTarget: 0
-  Lens:
-    FieldOfView: 50
-    OrthographicSize: 5
-    NearClipPlane: 0.3
-    FarClipPlane: 1000
-    Dutch: 0
-    ModeOverride: 0
-    PhysicalProperties:
-      GateFit: 2
-      SensorSize: {x: 21.946, y: 16.002}
-      LensShift: {x: 0, y: 0}
-      FocusDistance: 10
-      Iso: 200
-      ShutterSpeed: 0.005
-      Aperture: 16
-      BladeCount: 5
-      Curvature: {x: 2, y: 11}
-      BarrelClipping: 0.25
-      Anamorphism: 0
-  BlendHint: 0
---- !u!4 &2117777435
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2117777433}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.5, y: 1.75, z: -4}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &637665896992865568
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3123,13 +3059,70 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+--- !u!1001 &8941122198464403569
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3869294919606562035, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
+      propertyPath: m_Name
+      value: LockOnCamera
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468934978331119998, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468934978331119998, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468934978331119998, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468934978331119998, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468934978331119998, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468934978331119998, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468934978331119998, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468934978331119998, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468934978331119998, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5468934978331119998, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a12584d220a7626498563601d8f7c9ec, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 660226417}
   - {fileID: 8627026476723282079}
-  - {fileID: 2117777435}
+  - {fileID: 8941122198464403569}
   - {fileID: 2023134374}
   - {fileID: 1058446001}
   - {fileID: 6767515062201692495}

--- a/Assets/Scenes/TestScenes/PlayerTestScene.unity
+++ b/Assets/Scenes/TestScenes/PlayerTestScene.unity
@@ -154,283 +154,17 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &269304728
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 269304735}
-  - component: {fileID: 269304734}
-  - component: {fileID: 269304733}
-  - component: {fileID: 269304732}
-  - component: {fileID: 269304731}
-  - component: {fileID: 269304730}
-  - component: {fileID: 269304736}
-  m_Layer: 0
-  m_Name: 'FreeLook Camera '
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &269304730
+--- !u!114 &269304734 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 1543495482878070137, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+  m_PrefabInstance: {fileID: 8627026476723282079}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 269304728}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 89875cdc57c54474a8a74efd9b2a3b5d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineInputAxisController
-  ScanRecursively: 1
-  SuppressInputWhileBlending: 1
-  IgnoreTimeScale: 0
-  m_ControllerManager:
-    Controllers:
-    - Name: Look Orbit X
-      Owner: {fileID: 269304733}
-      Enabled: 1
-      Input:
-        InputAction: {fileID: -5630151704836100654, guid: 1d6e640e716dc4ff6989b73d02023f2b, type: 3}
-        Gain: 1
-        LegacyInput: 
-        LegacyGain: 1
-        CancelDeltaTime: 0
-      InputValue: 0
-      Driver:
-        AccelTime: 0.2
-        DecelTime: 0.2
-    - Name: Look Orbit Y
-      Owner: {fileID: 269304733}
-      Enabled: 1
-      Input:
-        InputAction: {fileID: -5630151704836100654, guid: 1d6e640e716dc4ff6989b73d02023f2b, type: 3}
-        Gain: -1
-        LegacyInput: 
-        LegacyGain: 1
-        CancelDeltaTime: 0
-      InputValue: 0
-      Driver:
-        AccelTime: 0.2
-        DecelTime: 0.2
-    - Name: Orbit Scale
-      Owner: {fileID: 269304733}
-      Enabled: 1
-      Input:
-        InputAction: {fileID: 5082991133974614888, guid: 1d6e640e716dc4ff6989b73d02023f2b, type: 3}
-        Gain: -1
-        LegacyInput: 
-        LegacyGain: 1
-        CancelDeltaTime: 0
-      InputValue: 0
-      Driver:
-        AccelTime: 0
-        DecelTime: 0
-  PlayerIndex: -1
-  AutoEnableInputs: 1
---- !u!114 &269304731
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 269304728}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a076c17fe76165e4f8ed21498b877bf9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineFreeLookModifier
-  Easing: 0
-  Modifiers: []
-  references:
-    version: 2
-    RefIds: []
---- !u!114 &269304732
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 269304728}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f38bda98361e1de48a4ca2bd86ea3c17, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineRotationComposer
-  Composition:
-    ScreenPosition: {x: 0, y: 0.3}
-    DeadZone:
-      Enabled: 0
-      Size: {x: 0.2, y: 0.2}
-    HardLimits:
-      Enabled: 0
-      Size: {x: 0.8, y: 0.8}
-      Offset: {x: 0, y: 0}
-  CenterOnActivate: 1
-  TargetOffset: {x: 0, y: 0, z: 0}
-  Damping: {x: 0.5, y: 0.5}
-  Lookahead:
-    Enabled: 0
-    Time: 0
-    Smoothing: 0
-    IgnoreY: 0
---- !u!114 &269304733
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 269304728}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3b5d7c088409d9a40b7b09aa707777f8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineOrbitalFollow
-  TargetOffset: {x: 0, y: 0, z: 0}
-  TrackerSettings:
-    BindingMode: 4
-    PositionDamping: {x: 0, y: 0, z: 0}
-    AngularDampingMode: 0
-    RotationDamping: {x: 1, y: 1, z: 1}
-    QuaternionDamping: 1
-  OrbitStyle: 1
-  Radius: 5
-  Orbits:
-    Top:
-      Radius: 2
-      Height: 5
-    Center:
-      Radius: 4
-      Height: 2.25
-    Bottom:
-      Radius: 2.5
-      Height: 0.1
-    SplineCurvature: 0.5
-  RecenteringTarget: 2
-  HorizontalAxis:
-    Value: 0
-    Center: 0
-    Range: {x: -180, y: 180}
-    Wrap: 1
-    Recentering:
-      Enabled: 0
-      Wait: 1
-      Time: 2
-    Restrictions: 0
-  VerticalAxis:
-    Value: 17.5
-    Center: 17.5
-    Range: {x: -10, y: 45}
-    Wrap: 0
-    Recentering:
-      Enabled: 0
-      Wait: 1
-      Time: 2
-    Restrictions: 0
-  RadialAxis:
-    Value: 1
-    Center: 1
-    Range: {x: 1, y: 1}
-    Wrap: 0
-    Recentering:
-      Enabled: 0
-      Wait: 1
-      Time: 2
-    Restrictions: 0
---- !u!114 &269304734
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 269304728}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineCamera
-  Priority:
-    Enabled: 1
-    m_Value: 10
-  OutputChannel: 1
-  StandbyUpdate: 2
-  m_StreamingVersion: 20241001
-  m_LegacyPriority: 0
-  Target:
-    TrackingTarget: {fileID: 1298887711}
-    LookAtTarget: {fileID: 0}
-    CustomLookAtTarget: 0
-  Lens:
-    FieldOfView: 55
-    OrthographicSize: 5
-    NearClipPlane: 0.3
-    FarClipPlane: 1000
-    Dutch: 0
-    ModeOverride: 0
-    PhysicalProperties:
-      GateFit: 2
-      SensorSize: {x: 21.946, y: 16.002}
-      LensShift: {x: 0, y: 0}
-      FocusDistance: 10
-      Iso: 200
-      ShutterSpeed: 0.005
-      Aperture: 16
-      BladeCount: 5
-      Curvature: {x: 2, y: 11}
-      BarrelClipping: 0.25
-      Anamorphism: 0
-  BlendHint: 0
---- !u!4 &269304735
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 269304728}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.104633205, y: -0.000000020438375, z: 0.0000000021503366, w: 0.9945109}
-  m_LocalPosition: {x: 0, y: 2.25, z: -4}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &269304736
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 269304728}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ca7de3aefa901374ba29464584a3109a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineDecollider
-  CameraRadius: 0.4
-  Decollision:
-    Enabled: 1
-    ObstacleLayers:
-      serializedVersion: 2
-      m_Bits: 4294967295
-    UseFollowTarget:
-      Enabled: 0
-      YOffset: 0
-    Damping: 0.5
-    SmoothingTime: 0
-  TerrainResolution:
-    Enabled: 1
-    TerrainLayers:
-      serializedVersion: 2
-      m_Bits: 1
-    MaximumRaycast: 10
-    Damping: 0.5
 --- !u!1 &278074566
 GameObject:
   m_ObjectHideFlags: 0
@@ -2959,35 +2693,35 @@ PrefabInstance:
       objectReference: {fileID: 6767515062201692496}
     - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.x
-      value: 336.4163
+      value: -0.00016004656
       objectReference: {fileID: 0}
     - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.y
-      value: 84.580956
+      value: -0.00042434217
       objectReference: {fileID: 0}
     - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
-      value: 245.76157
+      value: 270.0006
       objectReference: {fileID: 0}
     - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.x
-      value: -0.014827222
+      value: -0.13971739
       objectReference: {fileID: 0}
     - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.y
-      value: 0.07325438
+      value: 0.020943493
       objectReference: {fileID: 0}
     - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.z
-      value: 2.9958272
+      value: 1.3377273
       objectReference: {fileID: 0}
     - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.x
-      value: 1
+      value: 0.9999999
       objectReference: {fileID: 0}
     - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.y
-      value: 1.0000001
+      value: 0.9999999
       objectReference: {fileID: 0}
     - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.z
@@ -3067,35 +2801,35 @@ PrefabInstance:
       objectReference: {fileID: 343663376}
     - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.x
-      value: 336.4163
+      value: -0.00016004656
       objectReference: {fileID: 0}
     - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.y
-      value: 84.580956
+      value: -0.00042434217
       objectReference: {fileID: 0}
     - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
-      value: 245.76157
+      value: 270.0006
       objectReference: {fileID: 0}
     - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.x
-      value: -0.014827222
+      value: -0.13971739
       objectReference: {fileID: 0}
     - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.y
-      value: 0.07325438
+      value: 0.020943493
       objectReference: {fileID: 0}
     - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.z
-      value: 2.9958272
+      value: 1.3377273
       objectReference: {fileID: 0}
     - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.x
-      value: 1
+      value: 0.9999999
       objectReference: {fileID: 0}
     - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.y
-      value: 1.0000001
+      value: 0.9999999
       objectReference: {fileID: 0}
     - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.z
@@ -3328,12 +3062,73 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c4008acd4782d8049b7fb58a471d5d46, type: 3}
+--- !u!1001 &8627026476723282079
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 396129334472459972, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+      propertyPath: m_Name
+      value: 'FreeLook Camera '
+      objectReference: {fileID: 0}
+    - target: {fileID: 1543495482878070137, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+      propertyPath: Target.TrackingTarget
+      value: 
+      objectReference: {fileID: 1298887711}
+    - target: {fileID: 6306472090074037060, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6306472090074037060, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 6306472090074037060, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6306472090074037060, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9945109
+      objectReference: {fileID: 0}
+    - target: {fileID: 6306472090074037060, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.104633205
+      objectReference: {fileID: 0}
+    - target: {fileID: 6306472090074037060, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.000000020438375
+      objectReference: {fileID: 0}
+    - target: {fileID: 6306472090074037060, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.0000000021503366
+      objectReference: {fileID: 0}
+    - target: {fileID: 6306472090074037060, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6306472090074037060, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6306472090074037060, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 53598e6629a141a4885b7995e7822c27, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 660226417}
-  - {fileID: 269304735}
+  - {fileID: 8627026476723282079}
   - {fileID: 2117777435}
   - {fileID: 2023134374}
   - {fileID: 1058446001}

--- a/Assets/Scripts/Camera/CameraManager.cs
+++ b/Assets/Scripts/Camera/CameraManager.cs
@@ -88,7 +88,9 @@ public class CameraManager : MonoBehaviour
     /// <summary>カメラシェイクを実行します。</summary>
     public async UniTask ExecutionCameraShake(CameraShakeData data)
     {
-        await _cameraShake.StartCameraShake(data);
+        var camera = IsLockedOn ? _lockOnCamera : _normalCamera;
+
+        await _cameraShake.StartCameraShake(camera, data);
     }
 
     /// <summary>カメラシェイクを強制停止します。</summary>
@@ -178,7 +180,7 @@ public class CameraManager : MonoBehaviour
         _mainCamera = Camera.main;
         ServiceLocator.Register(this);
 
-        _cameraShake = new CameraShake(_normalCamera);
+        _cameraShake = new CameraShake();
         _cameraFollowTarget = new GameObject("CameraFollowTarget").transform;
 
         _normalCamera.Priority = _normalPriority;

--- a/Assets/Scripts/Camera/CameraShake.cs
+++ b/Assets/Scripts/Camera/CameraShake.cs
@@ -2,38 +2,40 @@ using Cysharp.Threading.Tasks;
 using System;
 using System.Threading;
 using Unity.Cinemachine;
+using UnityEngine;
 
+[Serializable]
 public struct CameraShakeData
 {
     ///<summary>振幅</summary>
-    public float Amplitude;
+    public float Amplitude => _amplitude;
     ///<summary>周期</summary>
-    public float Frequency;
+    public float Frequency => _frequency;
     ///<summary>持続時間</summary>
-    public float Duration;
+    public float Duration => _duration;
+
+    [SerializeField] private float _amplitude;
+    [SerializeField] private float _frequency;
+    [SerializeField] private float _duration;
 }
 
 public class CameraShake
 {
     /// <summary>
-    /// コンストラクタ
-    /// </summary>
-    public CameraShake(CinemachineCamera playerCamera)
-    {
-        if (playerCamera == null) return;
-
-        _noise = playerCamera.GetCinemachineComponent(CinemachineCore.Stage.Noise)
-                 as CinemachineBasicMultiChannelPerlin;
-    }
-
-    /// <summary>
     /// CameraShakeを開始
     /// </summary>
     /// <param name="data"></param>
     /// <returns></returns>
-    public async UniTask StartCameraShake(CameraShakeData data)
+    public async UniTask StartCameraShake(CinemachineCamera camera,CameraShakeData data)
     {
-        if (_noise == null) return;
+        _noise = camera.GetCinemachineComponent(CinemachineCore.Stage.Noise)
+            as CinemachineBasicMultiChannelPerlin;
+
+        if (_noise == null)
+        {
+            Debug.LogWarning($"現在使用中のカメラ{camera.name} に CinemachineBasicMultiChannelPerlinがアタッチされていません。");
+            return;
+        }
 
         ForceStopCameraShake();
 

--- a/Assets/Scripts/Camera/CameraShake.cs
+++ b/Assets/Scripts/Camera/CameraShake.cs
@@ -28,6 +28,12 @@ public class CameraShake
     /// <returns></returns>
     public async UniTask StartCameraShake(CinemachineCamera camera, CameraShakeData data)
     {
+        if (camera == null)
+        {
+            Debug.LogWarning("カメラシェイク対象のカメラが設定されていません。");
+            return;
+        }
+
         var noise = camera.GetCinemachineComponent(CinemachineCore.Stage.Noise)
             as CinemachineBasicMultiChannelPerlin;
 
@@ -37,12 +43,15 @@ public class CameraShake
             return;
         }
 
-        _noise = noise;
+        ForceStopCameraShake();
+        var shakeCts = new CancellationTokenSource();
+        _shakeCts = shakeCts;
+        _activeNoise = noise;
 
         noise.AmplitudeGain = data.Amplitude;
         noise.FrequencyGain = data.Frequency;
 
-        await StopCameraShake(noise, data, _shakeCts.Token);
+        await StopCameraShake(noise, data, shakeCts, shakeCts.Token);
     }
 
     /// <summary>
@@ -50,6 +59,13 @@ public class CameraShake
     /// </summary>
     public void ForceStopCameraShake()
     {
+        if (_activeNoise != null)
+        {
+            _activeNoise.AmplitudeGain = 0;
+            _activeNoise.FrequencyGain = 0;
+            _activeNoise = null;
+        }
+
         if (_shakeCts == null) return;
 
         _shakeCts.Cancel();
@@ -57,16 +73,17 @@ public class CameraShake
         _shakeCts = null;
     }
 
-    private CinemachineBasicMultiChannelPerlin _noise;
+    private CinemachineBasicMultiChannelPerlin _activeNoise;
     private CancellationTokenSource _shakeCts;
 
     /// <summary>
     /// CameraShakeを停止
     /// </summary>
     private async UniTask StopCameraShake(
-    CinemachineBasicMultiChannelPerlin noise,
-    CameraShakeData data,
-    CancellationToken cancellationToken)
+        CinemachineBasicMultiChannelPerlin noise,
+        CameraShakeData data,
+        CancellationTokenSource cts,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -78,10 +95,17 @@ public class CameraShake
         }
         finally
         {
-            if (noise != null)
+            if (ReferenceEquals(_shakeCts, cts))
             {
-                noise.AmplitudeGain = 0;
-                noise.FrequencyGain = 0;
+                if (noise != null)
+                {
+                    noise.AmplitudeGain = 0;
+                    noise.FrequencyGain = 0;
+                }
+
+                _activeNoise = null;
+                _shakeCts.Dispose();
+                _shakeCts = null;
             }
         }
     }

--- a/Assets/Scripts/Camera/CameraShake.cs
+++ b/Assets/Scripts/Camera/CameraShake.cs
@@ -26,25 +26,23 @@ public class CameraShake
     /// </summary>
     /// <param name="data"></param>
     /// <returns></returns>
-    public async UniTask StartCameraShake(CinemachineCamera camera,CameraShakeData data)
+    public async UniTask StartCameraShake(CinemachineCamera camera, CameraShakeData data)
     {
-        _noise = camera.GetCinemachineComponent(CinemachineCore.Stage.Noise)
+        var noise = camera.GetCinemachineComponent(CinemachineCore.Stage.Noise)
             as CinemachineBasicMultiChannelPerlin;
 
-        if (_noise == null)
+        if (noise == null)
         {
             Debug.LogWarning($"現在使用中のカメラ{camera.name} に CinemachineBasicMultiChannelPerlinがアタッチされていません。");
             return;
         }
 
-        ForceStopCameraShake();
+        _noise = noise;
 
-        _shakeCts = new CancellationTokenSource();
+        noise.AmplitudeGain = data.Amplitude;
+        noise.FrequencyGain = data.Frequency;
 
-        _noise.AmplitudeGain = data.Amplitude;
-        _noise.FrequencyGain = data.Frequency;
-
-        await StopCameraShake(data, _shakeCts.Token);
+        await StopCameraShake(noise, data, _shakeCts.Token);
     }
 
     /// <summary>
@@ -65,7 +63,10 @@ public class CameraShake
     /// <summary>
     /// CameraShakeを停止
     /// </summary>
-    private async UniTask StopCameraShake(CameraShakeData data, CancellationToken cancellationToken)
+    private async UniTask StopCameraShake(
+    CinemachineBasicMultiChannelPerlin noise,
+    CameraShakeData data,
+    CancellationToken cancellationToken)
     {
         try
         {
@@ -77,10 +78,10 @@ public class CameraShake
         }
         finally
         {
-            if (_noise != null)
+            if (noise != null)
             {
-                _noise.AmplitudeGain = 0;
-                _noise.FrequencyGain = 0;
+                noise.AmplitudeGain = 0;
+                noise.FrequencyGain = 0;
             }
         }
     }

--- a/Assets/Scripts/Data/Player/AttackVariantData.cs
+++ b/Assets/Scripts/Data/Player/AttackVariantData.cs
@@ -69,6 +69,9 @@ public class AttackVariantData
     /// <summary> 雷の追加ダメージのデータ配列 </summary>
     public AdditionalLightningDamageData[] AdditionalLightningDamages => _additionalLightningDamages;
 
+    /// <summary> カメラシェイクのデータ </summary>
+    public CameraShakeData CameraShakeData => _cameraShakeData;
+
     /// <summary>
     /// 攻撃バリアントのフィールドをデフォルト値にリセットする
     /// </summary>
@@ -130,4 +133,7 @@ public class AttackVariantData
     [Header("雷の追加ダメージ")]
     [Tooltip("雷の追加ダメージのデータ")]
     [SerializeField] private AdditionalLightningDamageData[] _additionalLightningDamages;
+
+    [Header("カメラシェイク")]
+    [SerializeField] private CameraShakeData _cameraShakeData;
 }

--- a/Assets/Scripts/Player/AttackExecutor.cs
+++ b/Assets/Scripts/Player/AttackExecutor.cs
@@ -111,6 +111,9 @@ public class AttackExecutor : MonoBehaviour
         {
             OnHitConfirmed?.Invoke();
 
+            if (ServiceLocator.TryGet(out CameraManager cameraManager))
+                cameraManager.ExecutionCameraShake(variantData.CameraShakeData).Forget();
+
             // HitStop
             if (ServiceLocator.TryGet(out HitStopManager hitStop))
             {


### PR DESCRIPTION
https://github.com/NaritaShosei/ProjectGO/issues/228
上記のIsuueを対応しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 攻撃バリアントごとに、カメラシェイク設定（振幅・周波数・継続時間等）を保持・参照できるようになりました。  
  * 攻撃が命中して確定した際に、通常時／ロックオン時で適切なカメラへカメラシェイクが適用されるようになりました。  
  * エディタ上でカメラシェイクのデータを確認・設定しやすくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->