### PR TITLE
雷追撃と落雷のダメージ表示を青くできるように

### DIFF
--- a/Assets/Scripts/Data/Skill/LightningStrikeUpdater.cs
+++ b/Assets/Scripts/Data/Skill/LightningStrikeUpdater.cs
@@ -73,7 +73,11 @@ public class LightningStrikeUpdater : ISkillUpdater
                     }
                 };
 
-                enemy.TakeDamage(damageContext);
+                // このTakeDamage内で生成されるダメージポップアップだけ雷色にする。
+                using (DamagePopupColorScope.Use(DamagePopupColorScope.LightningColor))
+                {
+                    enemy.TakeDamage(damageContext);
+                }
             }
 
             if (keys.Count > 0)

--- a/Assets/Scripts/Player/AttackExecutor.cs
+++ b/Assets/Scripts/Player/AttackExecutor.cs
@@ -140,7 +140,10 @@ public class AttackExecutor : MonoBehaviour
         context.OnAfterAttack?.Invoke();
     }
 
+    [Header("攻撃対象のレイヤー")]
     [SerializeField] private LayerMask _layer;
+    [Header("Damage Popup")]
+    [SerializeField] private Color _lightningDamagePopupColor = DamagePopupColorScope.LightningColor;
     private IPlayerStats _playerStats;
     private SkillManager _skillManager;
 
@@ -202,13 +205,17 @@ public class AttackExecutor : MonoBehaviour
 
             if (enemy == null || enemy.IsDead) return;
 
-            enemy.TakeDamage(new DamageContext
+            // このTakeDamage内で生成されるダメージポップアップだけ雷色にする。
+            using (DamagePopupColorScope.Use(_lightningDamagePopupColor))
             {
-                AttackPower = power * data.LightningDamageMultiplier,
-                PlayerMode = mode,
-                IsCritical = false,
-                CriticalMultiplier = 1f,
-            });
+                enemy.TakeDamage(new DamageContext
+                {
+                    AttackPower = power * data.LightningDamageMultiplier,
+                    PlayerMode = mode,
+                    IsCritical = false,
+                    CriticalMultiplier = 1f,
+                });
+            }
         }
     }
 }

--- a/Assets/Scripts/UI/DamageUI/DamagePopupPresenter.cs
+++ b/Assets/Scripts/UI/DamageUI/DamagePopupPresenter.cs
@@ -34,12 +34,45 @@ public readonly struct DamagePopupViewModel
     public readonly bool IsWeakPoint;
     public readonly bool IsCritical;
     public readonly Vector3 WorldPosition;
+    public readonly Color? TextColor;
 
-    public DamagePopupViewModel(int damage, bool isWeakPoint, bool isCritical, Vector3 worldPosition)
+    public DamagePopupViewModel(int damage, bool isWeakPoint, bool isCritical, Vector3 worldPosition, Color? textColor = null)
     {
         Damage = damage;
         IsWeakPoint = isWeakPoint;
         IsCritical = isCritical;
         WorldPosition = worldPosition;
+        TextColor = textColor ?? DamagePopupColorScope.Current;
+    }
+}
+
+public static class DamagePopupColorScope
+{
+    public static readonly Color LightningColor = new Color(0.25f, 0.65f, 1f);
+
+    public static Color? Current => _current;
+
+    // Enemy側に表示色を渡さず、TakeDamage中に生成されるポップアップだけ一時的に色を差し替える。
+    public static IDisposable Use(Color color)
+    {
+        return new Scope(color);
+    }
+
+    private static Color? _current;
+
+    private sealed class Scope : IDisposable
+    {
+        public Scope(Color color)
+        {
+            _previous = _current;
+            _current = color;
+        }
+
+        public void Dispose()
+        {
+            _current = _previous;
+        }
+
+        private readonly Color? _previous;
     }
 }

--- a/Assets/Scripts/UI/DamageUI/DamagePopupView.cs
+++ b/Assets/Scripts/UI/DamageUI/DamagePopupView.cs
@@ -52,7 +52,7 @@ public class DamagePopupView : MonoBehaviour, IDamagePopupView, IPoolable
 
         _canvasGroup.alpha = 1f;
         _damageText.text = viewModel.Damage.ToString();
-        _damageText.color = viewModel.IsWeakPoint ? _weakColor : _normalColor;
+        _damageText.color = viewModel.TextColor ?? (viewModel.IsWeakPoint ? _weakColor : _normalColor);
         _criticalObj.SetActive(viewModel.IsCritical);
 
         var screenPos = _mainCamera.WorldToScreenPoint(viewModel.WorldPosition);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 特定の雷属性ダメージで、ダメージポップアップの文字色を雷色に表示できるようになりました。
  * ダメージ表示に個別の色指定が反映され、演出の見分けやすさが向上しました。

* **不具合修正**
  * 雷追加ダメージの表示色が、他のダメージ表示に影響しないようになりました。
  * 弱点表示の色は、色指定がない場合に従来どおり維持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->