### PR TITLE
ジャスト回避のポスプロ演出

### DIFF
--- a/Assets/Prefab/Player/TestPlayer.prefab
+++ b/Assets/Prefab/Player/TestPlayer.prefab
@@ -18,6 +18,7 @@ GameObject:
   - component: {fileID: 8069266211170886861}
   - component: {fileID: 5786415077606400648}
   - component: {fileID: 6126189937113880516}
+  - component: {fileID: 8966819175010067479}
   m_Layer: 3
   m_Name: TestPlayer
   m_TagString: Untagged
@@ -65,14 +66,7 @@ MonoBehaviour:
   _soundHandler: {fileID: 5786415077606400648}
   _targetCenter: {fileID: 3784771225125332287}
   _justDodgeSystem: {fileID: 6126189937113880516}
-  _hitStopData:
-    _baseDuration: 5
-    _timeScale: 0.1
-    _targetGroup: 14
-    _priority: 1
-    _weakPointMultiplier: 1.2
-    _breakOrKillMultiplier: 1.2
-    _weakAndBreakOrKillMultiplier: 1.4
+  _justDodgeEffectPlayer: {fileID: 8966819175010067479}
 --- !u!114 &6265858459617693970
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -217,6 +211,57 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::JustDodgeSystem
   _justDodgeFrame: 15
+--- !u!114 &8966819175010067479
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5847551565396971007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a674f9424e730c40a21e356cd8be0e1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::JustDodgeEffectPlayer
+  _hitStopData:
+    _baseDuration: 5
+    _timeScale: 0.1
+    _targetGroup: 14
+    _priority: 1
+    _weakPointMultiplier: 1.2
+    _breakOrKillMultiplier: 1.2
+    _weakAndBreakOrKillMultiplier: 1.4
+  _volume: {fileID: 0}
+  _vignetteMin: 0.116
+  _vignetteMax: 0.719
+  _vignetteDuration: 5
+  _vignetteCloseDuration: 0.3
+  _vignetteCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 1
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 1
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  _defaultVignetteColor: {r: 0, g: 0, b: 0, a: 1}
+  _vignetteColor: {r: 0.18555348, g: 0.6405652, b: 0.82641506, a: 1}
 --- !u!1 &6848730639649579340
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/JustDodgeEffectPlayer.cs
+++ b/Assets/Scripts/Player/JustDodgeEffectPlayer.cs
@@ -100,6 +100,12 @@ public class JustDodgeEffectPlayer : MonoBehaviour
 
     private void OnDestroy()
     {
+        if (_vignette != null)
+        {
+            _vignette.intensity.value = _vignetteMin;
+            _vignette.color.value = _defaultVignetteColor;
+        }
+
         _vignetteCts?.Cancel();
         _vignetteCts?.Dispose();
         _vignetteCts = null;

--- a/Assets/Scripts/Player/JustDodgeEffectPlayer.cs
+++ b/Assets/Scripts/Player/JustDodgeEffectPlayer.cs
@@ -1,0 +1,114 @@
+using Cysharp.Threading.Tasks;
+using System;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+public class JustDodgeEffectPlayer : MonoBehaviour
+{
+    public void Play(JustDodgeContext context)
+    {
+        if (ServiceLocator.TryGet(out HitStopManager hitStopManager))
+        {
+            hitStopManager.Trigger(_hitStopData);
+        }
+
+        _vignetteCts?.Cancel();
+        _vignetteCts?.Dispose();
+        _vignetteCts = CancellationTokenSource.CreateLinkedTokenSource(destroyCancellationToken);
+
+        PlayVignette(_vignetteCts.Token).Forget();
+    }
+
+    [Header("ヒットストップ設定")]
+    [SerializeField] private HitStopData _hitStopData;
+    [Header("ポストプロセス設定")]
+    [SerializeField] private Volume _volume;
+    [SerializeField, Range(0, 1)] private float _vignetteMin = 0.116f;
+    [SerializeField, Range(0, 1)] private float _vignetteMax = 0.8f;
+    [SerializeField] private float _vignetteDuration = 1f;
+    [SerializeField] private float _vignetteCloseDuration = 0.3f;
+    [SerializeField] private AnimationCurve _vignetteCurve = AnimationCurve.Linear(0f, 0f, 1f, 1f);
+    [SerializeField] private Color _defaultVignetteColor = Color.black;
+    [SerializeField] private Color _vignetteColor = Color.skyBlue;
+
+    private Vignette _vignette;
+    private CancellationTokenSource _vignetteCts;
+
+    private void Awake()
+    {
+        // nullだったときに探す
+        if (_volume == null)
+            _volume = FindAnyObjectByType<Volume>();
+
+        if (_volume == null)
+        {
+            Debug.LogWarning("[JustDodgeEffectPlayer] GlobalVolume がシーンに存在しません");
+            return;
+        }
+
+        if (!_volume.profile.TryGet(out _vignette))
+            Debug.LogWarning("[JustDodgeEffectPlayer] GlobalVolume に Vignette が存在しません");
+    }
+
+    private async UniTask PlayVignette(CancellationToken token)
+    {
+        if (_vignette == null) return;
+
+        _vignette.color.value = _vignetteColor;
+        _vignette.intensity.value = _vignetteMax;
+
+        try
+        {
+            if (_vignetteDuration > 0f)
+            {
+                await UniTask.Delay(
+                    TimeSpan.FromSeconds(_vignetteDuration),
+                    DelayType.UnscaledDeltaTime,
+                    PlayerLoopTiming.Update,
+                    token
+                );
+            }
+
+            float elapsed = 0f;
+
+            while (elapsed < _vignetteCloseDuration)
+            {
+                elapsed += Time.unscaledDeltaTime;
+
+                float t = Mathf.Clamp01(elapsed / _vignetteCloseDuration);
+                float curveValue = _vignetteCurve.Evaluate(t);
+
+                _vignette.intensity.value = Mathf.Lerp(
+                    _vignetteMax,
+                    _vignetteMin,
+                    curveValue
+                );
+
+                await UniTask.Yield(token);
+            }
+
+            _vignette.intensity.value = _vignetteMin;
+            _vignette.color.value = _defaultVignetteColor;
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+    }
+
+    private void OnDestroy()
+    {
+        _vignetteCts?.Cancel();
+        _vignetteCts?.Dispose();
+        _vignetteCts = null;
+    }
+}
+
+public struct JustDodgeContext
+{
+    // KISSの原則には反しているが許して
+    // 今後必要になるかもしれないので作った。
+    // 不必要なら削除する
+}

--- a/Assets/Scripts/Player/JustDodgeEffectPlayer.cs.meta
+++ b/Assets/Scripts/Player/JustDodgeEffectPlayer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1a674f9424e730c40a21e356cd8be0e1

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -359,7 +359,7 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
     {
         var context = new JustDodgeContext();
 
-        _justDodgeEffectPlayer.Play(context);
+        _justDodgeEffectPlayer?.Play(context);
     }
 
     private void OnPlayerDead()

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -206,9 +206,7 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
     [SerializeField] private PlayerSoundHandler _soundHandler;
     [SerializeField] private Transform _targetCenter;
     [SerializeField] private JustDodgeSystem _justDodgeSystem;
-
-    [Header("ヒットストップ設定")]
-    [SerializeField] private HitStopData _hitStopData;
+    [SerializeField] private JustDodgeEffectPlayer _justDodgeEffectPlayer;
 
     private PlayerStateManager _playerStateManager;
     private PlayerStats _playerStats;
@@ -353,11 +351,9 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
     /// </summary>
     private void HandleJustDodgeSuccess()
     {
-        // TODO:ここに直書きではなく、JustDodgeEffectPlayerのようなクラスをはさんだほうがいい
+        var context = new JustDodgeContext();
 
-        if (!ServiceLocator.TryGet(out HitStopManager hitStopManager)) return;
-
-        hitStopManager.Trigger(_hitStopData);
+        _justDodgeEffectPlayer.Play(context);
     }
 
     private void OnPlayerDead()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ジャスト回避成功時に、ヒットストップとビネット演出が自動で再生されるようになりました。
  * ビネット演出は一定時間の後、滑らかに強度が変化して終了します。
  * 必要な映像設定が見つからない場合でも、警告を出して処理を続行します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->