### PR TITLE
仕様がないのでCodexのセンスに頼ったモードチェンジの演出

### DIFF
--- a/Assets/Prefab/Player/TestPlayer.prefab
+++ b/Assets/Prefab/Player/TestPlayer.prefab
@@ -19,6 +19,7 @@ GameObject:
   - component: {fileID: 5786415077606400648}
   - component: {fileID: 6126189937113880516}
   - component: {fileID: 8966819175010067479}
+  - component: {fileID: 3339426191168238841}
   m_Layer: 3
   m_Name: TestPlayer
   m_TagString: Untagged
@@ -262,6 +263,70 @@ MonoBehaviour:
     m_RotationOrder: 4
   _defaultVignetteColor: {r: 0, g: 0, b: 0, a: 1}
   _vignetteColor: {r: 0.18555348, g: 0.6405652, b: 0.82641506, a: 1}
+--- !u!114 &3339426191168238841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5847551565396971007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 036cc4329416404989a0c5667105fc96, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ModeChangePostProcessEffectPlayer
+  _modeController: {fileID: 4412391866698522038}
+  _volume: {fileID: 0}
+  _duration: 1.1
+  _impactCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.18
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.42
+      value: 0.55
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  _vignetteColor: {r: 0.25, g: 0.75, b: 1, a: 1}
+  _vignetteIntensity: 0.48
+  _chromaticAberrationIntensity: 0.75
+  _lensDistortionIntensity: -0.28
+  _bloomIntensityBoost: 6
+  _postExposureBoost: 1.2
+  _saturationBoost: 35
 --- !u!1 &6848730639649579340
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/JustDodgeEffectPlayer.cs
+++ b/Assets/Scripts/Player/JustDodgeEffectPlayer.cs
@@ -5,6 +5,10 @@ using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
 
+/// <summary>
+/// ジャスト回避成功時のヒットストップと画面 Vignette 演出を再生する。
+/// Vignette は再生前の値を保存し、演出終了時に元の状態へ戻す。
+/// </summary>
 public class JustDodgeEffectPlayer : MonoBehaviour
 {
     public void Play(JustDodgeContext context)
@@ -14,50 +18,64 @@ public class JustDodgeEffectPlayer : MonoBehaviour
             hitStopManager.Trigger(_hitStopData);
         }
 
-        _vignetteCts?.Cancel();
-        _vignetteCts?.Dispose();
-        _vignetteCts = CancellationTokenSource.CreateLinkedTokenSource(destroyCancellationToken);
+        StopVignette(restore: true);
 
-        PlayVignette(_vignetteCts.Token).Forget();
+        _vignetteCts = CancellationTokenSource.CreateLinkedTokenSource(destroyCancellationToken);
+        _vignettePlayVersion++;
+
+        PlayVignette(_vignetteCts.Token, _vignettePlayVersion).Forget();
     }
 
     [Header("ヒットストップ設定")]
     [SerializeField] private HitStopData _hitStopData;
+
     [Header("ポストプロセス設定")]
     [SerializeField] private Volume _volume;
-    [SerializeField, Range(0, 1)] private float _vignetteMin = 0.116f;
-    [SerializeField, Range(0, 1)] private float _vignetteMax = 0.8f;
+    [Tooltip("ジャスト回避直後の Vignette 強度")]
+    [SerializeField, Range(0, 1)] private float _vignetteIntensity = 0.8f;
+    [Tooltip("Vignette を最大値で維持する時間")]
     [SerializeField] private float _vignetteDuration = 1f;
+    [Tooltip("Vignette を演出前の値へ戻す時間")]
     [SerializeField] private float _vignetteCloseDuration = 0.3f;
+    [Tooltip("Vignette を戻す時の補間カーブ")]
     [SerializeField] private AnimationCurve _vignetteCurve = AnimationCurve.Linear(0f, 0f, 1f, 1f);
-    [SerializeField] private Color _defaultVignetteColor = Color.black;
+    [Tooltip("ジャスト回避時の Vignette 色")]
     [SerializeField] private Color _vignetteColor = Color.skyBlue;
 
     private Vignette _vignette;
     private CancellationTokenSource _vignetteCts;
+    private VignetteSnapshot _activeSnapshot;
+    private bool _hasActiveSnapshot;
+    private int _vignettePlayVersion;
 
     private void Awake()
     {
-        // nullだったときに探す
+        // 未設定ならシーン内の Volume を探す。
         if (_volume == null)
             _volume = FindAnyObjectByType<Volume>();
 
         if (_volume == null)
         {
-            Debug.LogWarning("[JustDodgeEffectPlayer] GlobalVolume がシーンに存在しません");
+            Debug.LogWarning("[JustDodgeEffectPlayer] GlobalVolume is missing.");
             return;
         }
 
         if (!_volume.profile.TryGet(out _vignette))
-            Debug.LogWarning("[JustDodgeEffectPlayer] GlobalVolume に Vignette が存在しません");
+            Debug.LogWarning("[JustDodgeEffectPlayer] GlobalVolume に Vignette が存在しません。");
     }
 
-    private async UniTask PlayVignette(CancellationToken token)
+    private async UniTask PlayVignette(CancellationToken token, int playVersion)
     {
         if (_vignette == null) return;
 
+        var snapshot = CaptureSnapshot();
+        _activeSnapshot = snapshot;
+        _hasActiveSnapshot = true;
+
+        _vignette.color.overrideState = true;
+        _vignette.intensity.overrideState = true;
         _vignette.color.value = _vignetteColor;
-        _vignette.intensity.value = _vignetteMax;
+        _vignette.intensity.value = _vignetteIntensity;
 
         try
         {
@@ -81,34 +99,71 @@ public class JustDodgeEffectPlayer : MonoBehaviour
                 float curveValue = _vignetteCurve.Evaluate(t);
 
                 _vignette.intensity.value = Mathf.Lerp(
-                    _vignetteMax,
-                    _vignetteMin,
+                    _vignetteIntensity,
+                    snapshot.Intensity,
                     curveValue
                 );
 
                 await UniTask.Yield(token);
             }
-
-            _vignette.intensity.value = _vignetteMin;
-            _vignette.color.value = _defaultVignetteColor;
         }
         catch (OperationCanceledException)
         {
             return;
         }
+        finally
+        {
+            // 連続再生時、古い非同期処理が新しい演出の値を戻してしまうのを防ぐ。
+            if (playVersion == _vignettePlayVersion)
+                RestoreSnapshot(snapshot);
+        }
     }
 
     private void OnDestroy()
     {
+        StopVignette(restore: true);
+    }
+
+    private VignetteSnapshot CaptureSnapshot()
+    {
+        return new VignetteSnapshot
+        {
+            Intensity = _vignette.intensity.value,
+            Color = _vignette.color.value,
+            IntensityOverride = _vignette.intensity.overrideState,
+            ColorOverride = _vignette.color.overrideState,
+        };
+    }
+
+    private void RestoreSnapshot(VignetteSnapshot snapshot)
+    {
         if (_vignette != null)
         {
-            _vignette.intensity.value = _vignetteMin;
-            _vignette.color.value = _defaultVignetteColor;
+            _vignette.intensity.value = snapshot.Intensity;
+            _vignette.color.value = snapshot.Color;
+            _vignette.intensity.overrideState = snapshot.IntensityOverride;
+            _vignette.color.overrideState = snapshot.ColorOverride;
         }
 
+        _hasActiveSnapshot = false;
+    }
+
+    private void StopVignette(bool restore)
+    {
         _vignetteCts?.Cancel();
         _vignetteCts?.Dispose();
         _vignetteCts = null;
+
+        if (restore && _hasActiveSnapshot)
+            RestoreSnapshot(_activeSnapshot);
+    }
+
+    private struct VignetteSnapshot
+    {
+        public float Intensity;
+        public Color Color;
+        public bool IntensityOverride;
+        public bool ColorOverride;
     }
 }
 

--- a/Assets/Scripts/Player/ModeChangePostProcessEffectPlayer.cs
+++ b/Assets/Scripts/Player/ModeChangePostProcessEffectPlayer.cs
@@ -1,0 +1,296 @@
+using Cysharp.Threading.Tasks;
+using System;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+/// <summary>
+/// Warrior から Thunder へ切り替わる瞬間だけ、画面全体のポストプロセス演出を再生する。
+/// モード変更ロジックには触らず、PlayerModeController のイベントを購読して演出だけを担当する。
+/// </summary>
+public class ModeChangePostProcessEffectPlayer : MonoBehaviour
+{
+    [Header("References")]
+    [SerializeField] private PlayerModeController _modeController;
+    [Tooltip("未設定の場合はシーン内の Volume を自動取得します。")]
+    [SerializeField] private Volume _volume;
+
+    [Header("Timing")]
+    [Tooltip("演出全体の再生時間")]
+    [SerializeField, Min(0.01f)] private float _duration = 1.1f;
+    [Tooltip("演出の強さの時間変化")]
+    [SerializeField] private AnimationCurve _impactCurve = new AnimationCurve(
+        new Keyframe(0f, 0f),
+        new Keyframe(0.18f, 1f),
+        new Keyframe(0.42f, 0.55f),
+        new Keyframe(1f, 0f));
+
+    [Header("Look")]
+    [Tooltip("雷神モード突入時の Vignette 色")]
+    [SerializeField] private Color _vignetteColor = new Color(0.25f, 0.75f, 1f);
+    [Tooltip("演出ピーク時の Vignette 強度")]
+    [SerializeField, Range(0f, 1f)] private float _vignetteIntensity = 0.48f;
+    [Tooltip("演出ピーク時の色収差の強度")]
+    [SerializeField, Range(0f, 1f)] private float _chromaticAberrationIntensity = 0.75f;
+    [Tooltip("演出ピーク時のレンズ歪み。負数にすると中心へ吸い込む印象になる")]
+    [SerializeField, Range(-1f, 1f)] private float _lensDistortionIntensity = -0.28f;
+    [Tooltip("現在の Bloom 強度に加算する値")]
+    [SerializeField, Min(0f)] private float _bloomIntensityBoost = 6f;
+    [Tooltip("現在の露出に加算する値")]
+    [SerializeField] private float _postExposureBoost = 1.2f;
+    [Tooltip("現在の彩度に加算する値")]
+    [SerializeField] private float _saturationBoost = 35f;
+
+    private PlayerMode _previousMode = PlayerMode.Warrior;
+    private Vignette _vignette;
+    private ChromaticAberration _chromaticAberration;
+    private LensDistortion _lensDistortion;
+    private Bloom _bloom;
+    private ColorAdjustments _colorAdjustments;
+    private CancellationTokenSource _effectCts;
+
+    private void Awake()
+    {
+        if (_modeController == null)
+            _modeController = GetComponent<PlayerModeController>();
+
+        if (_volume == null)
+            _volume = FindAnyObjectByType<Volume>();
+
+        if (_modeController != null)
+            _previousMode = _modeController.CurrentMode;
+
+        CacheVolumeComponents();
+    }
+
+    private void OnEnable()
+    {
+        if (_modeController != null)
+            _modeController.OnModeChanged += HandleModeChanged;
+    }
+
+    private void OnDisable()
+    {
+        if (_modeController != null)
+            _modeController.OnModeChanged -= HandleModeChanged;
+
+        StopEffect();
+    }
+
+    private void HandleModeChanged(PlayerMode newMode)
+    {
+        // OnModeChanged は遷移後のモードだけを通知するため、このクラス側で直前のモードを保持する。
+        bool isWarriorToThunder = _previousMode == PlayerMode.Warrior
+            && newMode == PlayerMode.Thunder;
+
+        _previousMode = newMode;
+
+        if (!isWarriorToThunder) return;
+
+        StopEffect();
+        _effectCts = CancellationTokenSource.CreateLinkedTokenSource(destroyCancellationToken);
+        PlayEffect(_effectCts.Token).Forget();
+    }
+
+    private void CacheVolumeComponents()
+    {
+        if (_volume == null)
+        {
+            Debug.LogWarning("[ModeChangePostProcessEffectPlayer] Volume is missing.", this);
+            return;
+        }
+
+        if (_volume.profile == null)
+        {
+            Debug.LogWarning("[ModeChangePostProcessEffectPlayer] Volume profile is missing.", this);
+            return;
+        }
+
+        // Profile に存在するコンポーネントだけを操作する。
+        // どれかが未設定でも、残りのポストプロセスだけで演出できるようにしている。
+        _volume.profile.TryGet(out _vignette);
+        _volume.profile.TryGet(out _chromaticAberration);
+        _volume.profile.TryGet(out _lensDistortion);
+        _volume.profile.TryGet(out _bloom);
+        _volume.profile.TryGet(out _colorAdjustments);
+    }
+
+    private async UniTaskVoid PlayEffect(CancellationToken token)
+    {
+        if (_volume == null || _volume.profile == null) return;
+
+        // 他の演出やシーンの初期値を壊さないよう、再生前の値と overrideState を保存して最後に戻す。
+        var snapshot = CaptureSnapshot();
+        SetOverrideState(true);
+
+        float elapsed = 0f;
+
+        try
+        {
+            while (elapsed < _duration)
+            {
+                elapsed += Time.unscaledDeltaTime;
+                float normalizedTime = Mathf.Clamp01(elapsed / _duration);
+                float strength = Mathf.Clamp01(_impactCurve.Evaluate(normalizedTime));
+
+                Apply(strength, snapshot);
+
+                await UniTask.Yield(PlayerLoopTiming.Update, token);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        finally
+        {
+            Restore(snapshot);
+        }
+    }
+
+    private PostProcessSnapshot CaptureSnapshot()
+    {
+        return new PostProcessSnapshot
+        {
+            VignetteIntensity = _vignette != null ? _vignette.intensity.value : 0f,
+            VignetteColor = _vignette != null ? _vignette.color.value : Color.black,
+            VignetteIntensityOverride = _vignette != null && _vignette.intensity.overrideState,
+            VignetteColorOverride = _vignette != null && _vignette.color.overrideState,
+
+            ChromaticAberrationIntensity = _chromaticAberration != null ? _chromaticAberration.intensity.value : 0f,
+            ChromaticAberrationOverride = _chromaticAberration != null && _chromaticAberration.intensity.overrideState,
+
+            LensDistortionIntensity = _lensDistortion != null ? _lensDistortion.intensity.value : 0f,
+            LensDistortionOverride = _lensDistortion != null && _lensDistortion.intensity.overrideState,
+
+            BloomIntensity = _bloom != null ? _bloom.intensity.value : 0f,
+            BloomOverride = _bloom != null && _bloom.intensity.overrideState,
+
+            PostExposure = _colorAdjustments != null ? _colorAdjustments.postExposure.value : 0f,
+            Saturation = _colorAdjustments != null ? _colorAdjustments.saturation.value : 0f,
+            PostExposureOverride = _colorAdjustments != null && _colorAdjustments.postExposure.overrideState,
+            SaturationOverride = _colorAdjustments != null && _colorAdjustments.saturation.overrideState,
+        };
+    }
+
+    private void SetOverrideState(bool enabled)
+    {
+        if (_vignette != null)
+        {
+            _vignette.intensity.overrideState = enabled;
+            _vignette.color.overrideState = enabled;
+        }
+
+        if (_chromaticAberration != null)
+            _chromaticAberration.intensity.overrideState = enabled;
+
+        if (_lensDistortion != null)
+            _lensDistortion.intensity.overrideState = enabled;
+
+        if (_bloom != null)
+            _bloom.intensity.overrideState = enabled;
+
+        if (_colorAdjustments != null)
+        {
+            _colorAdjustments.postExposure.overrideState = enabled;
+            _colorAdjustments.saturation.overrideState = enabled;
+        }
+    }
+
+    private void Apply(float strength, PostProcessSnapshot snapshot)
+    {
+        if (_vignette != null)
+        {
+            _vignette.intensity.value = Mathf.Lerp(snapshot.VignetteIntensity, _vignetteIntensity, strength);
+            _vignette.color.value = Color.Lerp(snapshot.VignetteColor, _vignetteColor, strength);
+        }
+
+        if (_chromaticAberration != null)
+        {
+            _chromaticAberration.intensity.value = Mathf.Lerp(
+                snapshot.ChromaticAberrationIntensity,
+                _chromaticAberrationIntensity,
+                strength);
+        }
+
+        if (_lensDistortion != null)
+        {
+            _lensDistortion.intensity.value = Mathf.Lerp(
+                snapshot.LensDistortionIntensity,
+                _lensDistortionIntensity,
+                strength);
+        }
+
+        if (_bloom != null)
+            _bloom.intensity.value = snapshot.BloomIntensity + _bloomIntensityBoost * strength;
+
+        if (_colorAdjustments != null)
+        {
+            _colorAdjustments.postExposure.value = snapshot.PostExposure + _postExposureBoost * strength;
+            _colorAdjustments.saturation.value = snapshot.Saturation + _saturationBoost * strength;
+        }
+    }
+
+    private void Restore(PostProcessSnapshot snapshot)
+    {
+        if (_vignette != null)
+        {
+            _vignette.intensity.value = snapshot.VignetteIntensity;
+            _vignette.color.value = snapshot.VignetteColor;
+            _vignette.intensity.overrideState = snapshot.VignetteIntensityOverride;
+            _vignette.color.overrideState = snapshot.VignetteColorOverride;
+        }
+
+        if (_chromaticAberration != null)
+        {
+            _chromaticAberration.intensity.value = snapshot.ChromaticAberrationIntensity;
+            _chromaticAberration.intensity.overrideState = snapshot.ChromaticAberrationOverride;
+        }
+
+        if (_lensDistortion != null)
+        {
+            _lensDistortion.intensity.value = snapshot.LensDistortionIntensity;
+            _lensDistortion.intensity.overrideState = snapshot.LensDistortionOverride;
+        }
+
+        if (_bloom != null)
+        {
+            _bloom.intensity.value = snapshot.BloomIntensity;
+            _bloom.intensity.overrideState = snapshot.BloomOverride;
+        }
+
+        if (_colorAdjustments != null)
+        {
+            _colorAdjustments.postExposure.value = snapshot.PostExposure;
+            _colorAdjustments.saturation.value = snapshot.Saturation;
+            _colorAdjustments.postExposure.overrideState = snapshot.PostExposureOverride;
+            _colorAdjustments.saturation.overrideState = snapshot.SaturationOverride;
+        }
+    }
+
+    private void StopEffect()
+    {
+        _effectCts?.Cancel();
+        _effectCts?.Dispose();
+        _effectCts = null;
+    }
+
+    private struct PostProcessSnapshot
+    {
+        public float VignetteIntensity;
+        public Color VignetteColor;
+        public bool VignetteIntensityOverride;
+        public bool VignetteColorOverride;
+        public float ChromaticAberrationIntensity;
+        public bool ChromaticAberrationOverride;
+        public float LensDistortionIntensity;
+        public bool LensDistortionOverride;
+        public float BloomIntensity;
+        public bool BloomOverride;
+        public float PostExposure;
+        public float Saturation;
+        public bool PostExposureOverride;
+        public bool SaturationOverride;
+    }
+}

--- a/Assets/Scripts/Player/ModeChangePostProcessEffectPlayer.cs
+++ b/Assets/Scripts/Player/ModeChangePostProcessEffectPlayer.cs
@@ -11,12 +11,12 @@ using UnityEngine.Rendering.Universal;
 /// </summary>
 public class ModeChangePostProcessEffectPlayer : MonoBehaviour
 {
-    [Header("References")]
+    [Header("参照")]
     [SerializeField] private PlayerModeController _modeController;
     [Tooltip("未設定の場合はシーン内の Volume を自動取得します。")]
     [SerializeField] private Volume _volume;
 
-    [Header("Timing")]
+    [Header("時間設定")]
     [Tooltip("演出全体の再生時間")]
     [SerializeField, Min(0.01f)] private float _duration = 1.1f;
     [Tooltip("演出の強さの時間変化")]
@@ -26,7 +26,7 @@ public class ModeChangePostProcessEffectPlayer : MonoBehaviour
         new Keyframe(0.42f, 0.55f),
         new Keyframe(1f, 0f));
 
-    [Header("Look")]
+    [Header("見た目")]
     [Tooltip("雷神モード突入時の Vignette 色")]
     [SerializeField] private Color _vignetteColor = new Color(0.25f, 0.75f, 1f);
     [Tooltip("演出ピーク時の Vignette 強度")]
@@ -49,6 +49,9 @@ public class ModeChangePostProcessEffectPlayer : MonoBehaviour
     private Bloom _bloom;
     private ColorAdjustments _colorAdjustments;
     private CancellationTokenSource _effectCts;
+    private PostProcessSnapshot _activeSnapshot;
+    private bool _hasActiveSnapshot;
+    private int _effectPlayVersion;
 
     private void Awake()
     {
@@ -75,7 +78,7 @@ public class ModeChangePostProcessEffectPlayer : MonoBehaviour
         if (_modeController != null)
             _modeController.OnModeChanged -= HandleModeChanged;
 
-        StopEffect();
+        StopEffect(restore: true);
     }
 
     private void HandleModeChanged(PlayerMode newMode)
@@ -88,27 +91,30 @@ public class ModeChangePostProcessEffectPlayer : MonoBehaviour
 
         if (!isWarriorToThunder) return;
 
-        StopEffect();
+        // 前回演出の停止と復元を先に完了させてから、次のスナップショットを取る。
+        StopEffect(restore: true);
+
         _effectCts = CancellationTokenSource.CreateLinkedTokenSource(destroyCancellationToken);
-        PlayEffect(_effectCts.Token).Forget();
+        _effectPlayVersion++;
+
+        PlayEffect(_effectCts.Token, _effectPlayVersion).Forget();
     }
 
     private void CacheVolumeComponents()
     {
         if (_volume == null)
         {
-            Debug.LogWarning("[ModeChangePostProcessEffectPlayer] Volume is missing.", this);
+            Debug.LogWarning("[ModeChangePostProcessEffectPlayer] Volume が存在しません。", this);
             return;
         }
 
         if (_volume.profile == null)
         {
-            Debug.LogWarning("[ModeChangePostProcessEffectPlayer] Volume profile is missing.", this);
+            Debug.LogWarning("[ModeChangePostProcessEffectPlayer] Volume Profile が存在しません。", this);
             return;
         }
 
         // Profile に存在するコンポーネントだけを操作する。
-        // どれかが未設定でも、残りのポストプロセスだけで演出できるようにしている。
         _volume.profile.TryGet(out _vignette);
         _volume.profile.TryGet(out _chromaticAberration);
         _volume.profile.TryGet(out _lensDistortion);
@@ -116,12 +122,14 @@ public class ModeChangePostProcessEffectPlayer : MonoBehaviour
         _volume.profile.TryGet(out _colorAdjustments);
     }
 
-    private async UniTaskVoid PlayEffect(CancellationToken token)
+    private async UniTask PlayEffect(CancellationToken token, int playVersion)
     {
         if (_volume == null || _volume.profile == null) return;
 
-        // 他の演出やシーンの初期値を壊さないよう、再生前の値と overrideState を保存して最後に戻す。
         var snapshot = CaptureSnapshot();
+        _activeSnapshot = snapshot;
+        _hasActiveSnapshot = true;
+
         SetOverrideState(true);
 
         float elapsed = 0f;
@@ -145,7 +153,9 @@ public class ModeChangePostProcessEffectPlayer : MonoBehaviour
         }
         finally
         {
-            Restore(snapshot);
+            // 連続再生時、古い非同期処理が新しい演出の値を戻してしまうのを防ぐ。
+            if (playVersion == _effectPlayVersion)
+                Restore(snapshot);
         }
     }
 
@@ -267,13 +277,18 @@ public class ModeChangePostProcessEffectPlayer : MonoBehaviour
             _colorAdjustments.postExposure.overrideState = snapshot.PostExposureOverride;
             _colorAdjustments.saturation.overrideState = snapshot.SaturationOverride;
         }
+
+        _hasActiveSnapshot = false;
     }
 
-    private void StopEffect()
+    private void StopEffect(bool restore)
     {
         _effectCts?.Cancel();
         _effectCts?.Dispose();
         _effectCts = null;
+
+        if (restore && _hasActiveSnapshot)
+            Restore(_activeSnapshot);
     }
 
     private struct PostProcessSnapshot

--- a/Assets/Scripts/Player/ModeChangePostProcessEffectPlayer.cs.meta
+++ b/Assets/Scripts/Player/ModeChangePostProcessEffectPlayer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 036cc4329416404989a0c5667105fc96


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * プレイヤーのモード切り替え時に、全画面の演出エフェクトを一時的に再生できるようになりました。
  * 特定のモード遷移では、数秒間かけて画面効果が滑らかに変化し、終了後は元の表示に自動で戻ります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->