### PR TITLE
Fix：初動の動きを固定

### DIFF
--- a/Assets/Data/BossEnemy/BehaviorTree/ID1_BossEnemyBehaviorTree.asset
+++ b/Assets/Data/BossEnemy/BehaviorTree/ID1_BossEnemyBehaviorTree.asset
@@ -12,6 +12,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b1dcb62f5f422149b3753f583e6e927, type: 3}
   m_Name: ID1_BossEnemyBehaviorTree
   m_EditorClassIdentifier: Assembly-CSharp::BossEnemyBehaviorTree
+  _firstPhaseFirstAttackSelectionPool:
+    _attackField:
+    - ID: 6
+      ActivationRate: 100
+  _secondPhaseFirstAttackSelectionPool:
+    _attackField:
+    - ID: 7
+      ActivationRate: 100
   _oneLegBreakDownTime: 10
   _allLegBreakDownTime: 15
   _normalAttackCount: 3

--- a/Assets/Prefab/Enemy/Boss/TestBoss.prefab
+++ b/Assets/Prefab/Enemy/Boss/TestBoss.prefab
@@ -106,7 +106,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::BossEnemyView
   _bossEnemyController:
-    _csvBossEnemyMasterData: {fileID: 4900000, guid: 0f0521962c1633040bb4dc704295ca87, type: 3}
+    _csvBossEnemyMasterData: {fileID: 4900000, guid: dcac7d650206e3440918e090e5b30480, type: 3}
     _bossEnemyBehaviorTree: {fileID: 11400000, guid: e399fdc048f9faa45a32193411b37d9b, type: 2}
     _id: 1
     _attackDataRepositry:

--- a/Assets/Scripts/Enemy/Boss/Application/BossEnemyController.cs
+++ b/Assets/Scripts/Enemy/Boss/Application/BossEnemyController.cs
@@ -217,7 +217,7 @@ namespace BossEnemy.Application
                 RegisterArmorDamageEventAction();
 
                 // BehaviorTreeのPhase切り替え処理
-                _bossEnemyBehaviorTree.HandlePhaseChanged(data, _attackDataRepositry, _enemyServices.PlayerInformationService);
+                _bossEnemyBehaviorTree.HandlePhaseChanged(_phaseChange.CurrentPhase, data, _attackDataRepositry, _enemyServices.PlayerInformationService);
 
 
                 // HPが0になったときフェーズを切り替える処理

--- a/Assets/Scripts/Enemy/Boss/Model/BehaiviorTree/BossEnemyBehaviorTree.cs
+++ b/Assets/Scripts/Enemy/Boss/Model/BehaiviorTree/BossEnemyBehaviorTree.cs
@@ -31,7 +31,9 @@ namespace BossEnemy.Model.BehaviorTree
             _behaviorController?.OnUpdate();
         }
 
-        public void HandlePhaseChanged(BossEnemyData bossEnemyData,
+        public void HandlePhaseChanged(
+            int currentPhase,
+            BossEnemyData bossEnemyData,
             IBossEnemyAttackDataRepository attackDataRepositry,
             IPlayerInformationService playerInformationService)
         {
@@ -41,10 +43,16 @@ namespace BossEnemy.Model.BehaviorTree
             _lookAtTargetAction = new(playerInformationService.Player.GetTargetCenter(),
                 _move, bossEnemyData, _lookSpeed, _finishAngleThreshold);
 
+            switch (currentPhase)
+            {
+                case _firstPhaseNum: _currentPhaseFirstAttackDataSelectionPool = _firstPhaseFirstAttackSelectionPool; break;
+                case _secondPhaseNum: _currentPhaseFirstAttackDataSelectionPool = _secondPhaseFirstAttackSelectionPool; break;
+            }
+
             ITreeNode[] originChildrenNode = new ITreeNode[]
             {
-                BuildArmorBreakActionTree(bossEnemyData),
-                BuildAttackActionTree(bossEnemyData, attackDataRepositry, playerInformationService)
+                GetArmorBreakActionTree(bossEnemyData),
+                GetAttackActionTree(bossEnemyData, attackDataRepositry, playerInformationService)
             };
 
             SelectorNode originNode = new(originChildrenNode);
@@ -75,6 +83,24 @@ namespace BossEnemy.Model.BehaviorTree
 
         // 初期化確認フラグ
         private bool _isInit = false;
+
+        #region Phase切り替え時の行動関連変数
+
+        [Header("-------Phase切り替え時の行動関連変数--------")]
+
+        [Header("最初のフェーズの最初の攻撃")]
+        [SerializeField] private AttackDataSelectionPool _firstPhaseFirstAttackSelectionPool = new AttackDataSelectionPool();
+
+        [Header("フェーズ2切り替え時の最初の攻撃")]
+        [SerializeField] private AttackDataSelectionPool _secondPhaseFirstAttackSelectionPool = new AttackDataSelectionPool();
+
+        private AttackDataSelectionPool _currentPhaseFirstAttackDataSelectionPool = null;
+        private PhaseChangedNode _phaseChangedNode = null;
+
+        private const int _firstPhaseNum = 0;
+        private const int _secondPhaseNum = 1;
+
+        #endregion
 
         #region 装備破壊時の行動関連変数
 
@@ -109,10 +135,12 @@ namespace BossEnemy.Model.BehaviorTree
         private CountDownNode _normalAttackCountDownNode;
 
         // 各攻撃選択肢ノード
-        private AttackSelect _closeRangeNormalAttackSelect;
-        private AttackSelect _closeRangeSpecialAttackSelect;
-        private AttackSelect _longRangeAttackSelect;
+        private AttackSelection _closeRangeNormalAttackSelect;
+        private AttackSelection _closeRangeSpecialAttackSelect;
+        private AttackSelection _longRangeAttackSelect;
+        private AttackSelection _phaseChangedFirstAttackSelect;
 
+        private SequenceNode _attackActionSequence;
         #endregion
 
         #region 移動行動関連変数
@@ -129,7 +157,7 @@ namespace BossEnemy.Model.BehaviorTree
 
         #endregion
 
-        private ITreeNode BuildArmorBreakActionTree(BossEnemyData bossEnemyData)
+        private ITreeNode GetArmorBreakActionTree(BossEnemyData bossEnemyData)
         {
             _downAction = new DownAction(bossEnemyData, _bossDown, _oneLegBreakDownTime, _allLegBreakDownTime);
 
@@ -140,7 +168,7 @@ namespace BossEnemy.Model.BehaviorTree
             return _breakArmorNode = new(downSequence);
         }
 
-        private ITreeNode BuildAttackActionTree(BossEnemyData bossEnemyData,
+        private ITreeNode GetAttackActionTree(BossEnemyData bossEnemyData,
             IBossEnemyAttackDataRepository dataRepositry,
             IPlayerInformationService playerInformationService)
         {
@@ -157,22 +185,25 @@ namespace BossEnemy.Model.BehaviorTree
             
             // 攻撃シーケンスを生成
             ITreeNode[] attackSequenceChildren = new ITreeNode[] { targetChaseAction, attackNode ,_lookAtTargetAction };
-            SequenceNode attackSequence = new(attackSequenceChildren);
+            _attackActionSequence = new(attackSequenceChildren);
 
             // ---攻撃選択ノード↓-------------------
 
             // 1.近距離通常攻撃
-            _closeRangeNormalAttackSelect = new(attackSequence, bossEnemyData.CloseRangeNormalAttackFieldHolder, 
+            _closeRangeNormalAttackSelect = new(_attackActionSequence, bossEnemyData.CloseRangeNormalAttackFieldHolder, 
                 dataRepositry, _attackCoolTimer, attackNode, targetChaseAction);
 
             // 2.通常攻撃3回以上攻撃
-            _closeRangeSpecialAttackSelect = new(attackSequence, bossEnemyData.CloseRangeFinishCountAttackFieldHolder, 
+            _closeRangeSpecialAttackSelect = new(_attackActionSequence, bossEnemyData.CloseRangeFinishCountAttackFieldHolder, 
                 dataRepositry, _attackCoolTimer, attackNode, targetChaseAction);
 
             // 3.遠距離攻撃
-            _longRangeAttackSelect = new(attackSequence, bossEnemyData.LongRangeAttackFieldHolder,
+            _longRangeAttackSelect = new(_attackActionSequence, bossEnemyData.LongRangeAttackFieldHolder,
                 dataRepositry, _attackCoolTimer, attackNode, targetChaseAction);
 
+            // 4.フェーズ切り替え時最初の攻撃
+            _phaseChangedFirstAttackSelect = new(_attackActionSequence, _currentPhaseFirstAttackDataSelectionPool,
+                dataRepositry, _attackCoolTimer, attackNode, targetChaseAction);
 
             // カウントダウンを行いカウントが0になったときに近距離の特殊攻撃を行うノード
             _normalAttackCountDownNode = new(_closeRangeSpecialAttackSelect, _normalAttackCount);
@@ -184,8 +215,12 @@ namespace BossEnemy.Model.BehaviorTree
             // ターゲットの距離を見て近いときはEntryできるノード
             CloseToPlayerNode closeRangeTarget = new(closeAttackSelector, playerInformationService, bossEnemyData, _bossTerritoryDistance);
 
+            // フェーズ切り替え時に一度だけは入れるノード
+            _phaseChangedNode = new(_phaseChangedFirstAttackSelect);
+            _phaseChangedNode.ChangePhase();
+
             // 上記のノード軍の最上位ノードを生成
-            ITreeNode[] attackSelectorChild = new ITreeNode[] { closeRangeTarget, _longRangeAttackSelect };
+            ITreeNode[] attackSelectorChild = new ITreeNode[] { _phaseChangedNode , closeRangeTarget, _longRangeAttackSelect };
             SelectorNode attackSelector = new(attackSelectorChild);
 
             return attackSelector;

--- a/Assets/Scripts/Enemy/Boss/Model/BehaiviorTree/Node/DecoratorNode.cs
+++ b/Assets/Scripts/Enemy/Boss/Model/BehaiviorTree/Node/DecoratorNode.cs
@@ -198,17 +198,32 @@ namespace BossEnemy.Model.BehaviorTree
 
         public override NodeCondition TryEntry()
         {
-            if (_canEntry)
+            if (!_canEntry || _childNode == null) return NodeCondition.Failure;
+
+            NodeCondition condition = _childNode.TryEntry();
+
+            if (condition != NodeCondition.Running && condition != NodeCondition.Success)
             {
-                _canEntry = false;
-                return NodeCondition.Success;
+                return NodeCondition.Failure;
             }
 
-            return NodeCondition.Failure;
+            _canEntry = false;
+            _hasEntryChild = true;
+            return NodeCondition.Success;
+        }
+
+        public override NodeCondition TryGetNextNode(ref ITreeNode nextNode)
+        {
+            if (!_hasEntryChild) return NodeCondition.Failure;
+
+            _hasEntryChild = false;
+            nextNode = _childNode;
+            return NodeCondition.Success;
         }
 
         private int _currentPhase = 0;
         private bool _canEntry = false;
+        private bool _hasEntryChild = false;
     }
     #endregion
 

--- a/Assets/Scripts/Enemy/Boss/Model/BehaiviorTree/Node/DecoratorNode.cs
+++ b/Assets/Scripts/Enemy/Boss/Model/BehaiviorTree/Node/DecoratorNode.cs
@@ -43,9 +43,9 @@ namespace BossEnemy.Model.BehaviorTree
     }
 
     /// <summary> 攻撃の選択Node </summary>
-    public class AttackSelect : DecoratorNode
+    public class AttackSelection : DecoratorNode
     {
-        public AttackSelect(ITreeNode child, 
+        public AttackSelection(ITreeNode child, 
             AttackDataSelectionPool bossEnemyAttackField, 
             IBossEnemyAttackDataRepository bossEnemyAttackDataRepositry, 
             AttackCoolTimer bossEnemyAttackCoolTimer,
@@ -179,6 +179,36 @@ namespace BossEnemy.Model.BehaviorTree
         }
 
         private ArmorAttachmentPointType _armorBreakingPoint = ArmorAttachmentPointType.None;
+    }
+    #endregion
+
+    #region Phaseが切り替わった際に一度だけEntryが可能となるDecoratorNode
+    public class PhaseChangedNode : DecoratorNode
+    {
+        public PhaseChangedNode(ITreeNode child) : base(child)
+        {
+            _childNode = child;
+            _canEntry = false;
+        }
+
+        public void ChangePhase()
+        {
+            _canEntry = true;
+        }
+
+        public override NodeCondition TryEntry()
+        {
+            if (_canEntry)
+            {
+                _canEntry = false;
+                return NodeCondition.Success;
+            }
+
+            return NodeCondition.Failure;
+        }
+
+        private int _currentPhase = 0;
+        private bool _canEntry = false;
     }
     #endregion
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ボスがフェーズ切り替え時に、状況に応じた最初の行動を選ぶようになりました。
  * フェーズ切り替え直後に一度だけ発生する特別な挙動が追加されました。

* **改善**
  * ボスの攻撃パターンが、近距離・遠距離・フェーズ変化後でより自然に切り替わるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->