### PR TITLE
スキル選択画面中はカメラが動かなくなるようにした

### DIFF
--- a/Assets/InputAction/PlayerInput.cs
+++ b/Assets/InputAction/PlayerInput.cs
@@ -163,6 +163,15 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": true
+                },
+                {
+                    ""name"": ""CameraMove"",
+                    ""type"": ""Value"",
+                    ""id"": ""94015e16-3a8b-44c5-8018-03a1176872f7"",
+                    ""expectedControlType"": ""Vector2"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": true
                 }
             ],
             ""bindings"": [
@@ -550,6 +559,39 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
                     ""action"": ""LockOnChange"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""983a713d-f5bf-40a7-8f56-1f2f9812dd37"",
+                    ""path"": ""<Mouse>/delta"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""CameraMove"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""c1f763e4-925b-4ce4-a144-0c73e9a02c7a"",
+                    ""path"": ""<Gamepad>/rightStick"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""CameraMove"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""9c506375-7c54-48d1-94c3-a84d1dc9cd8e"",
+                    ""path"": ""<XInputController>/rightStick"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""CameraMove"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
                 }
             ]
         },
@@ -1082,6 +1124,7 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
         m_Player_Interact = m_Player.FindAction("Interact", throwIfNotFound: true);
         m_Player_LockOn = m_Player.FindAction("LockOn", throwIfNotFound: true);
         m_Player_LockOnChange = m_Player.FindAction("LockOnChange", throwIfNotFound: true);
+        m_Player_CameraMove = m_Player.FindAction("CameraMove", throwIfNotFound: true);
         // UI
         m_UI = asset.FindActionMap("UI", throwIfNotFound: true);
         m_UI_Navigate = m_UI.FindAction("Navigate", throwIfNotFound: true);
@@ -1183,6 +1226,7 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
     private readonly InputAction m_Player_Interact;
     private readonly InputAction m_Player_LockOn;
     private readonly InputAction m_Player_LockOnChange;
+    private readonly InputAction m_Player_CameraMove;
     /// <summary>
     /// Provides access to input actions defined in input action map "Player".
     /// </summary>
@@ -1226,6 +1270,10 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
         /// Provides access to the underlying input action "Player/LockOnChange".
         /// </summary>
         public InputAction @LockOnChange => m_Wrapper.m_Player_LockOnChange;
+        /// <summary>
+        /// Provides access to the underlying input action "Player/CameraMove".
+        /// </summary>
+        public InputAction @CameraMove => m_Wrapper.m_Player_CameraMove;
         /// <summary>
         /// Provides access to the underlying input action map instance.
         /// </summary>
@@ -1276,6 +1324,9 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
             @LockOnChange.started += instance.OnLockOnChange;
             @LockOnChange.performed += instance.OnLockOnChange;
             @LockOnChange.canceled += instance.OnLockOnChange;
+            @CameraMove.started += instance.OnCameraMove;
+            @CameraMove.performed += instance.OnCameraMove;
+            @CameraMove.canceled += instance.OnCameraMove;
         }
 
         /// <summary>
@@ -1311,6 +1362,9 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
             @LockOnChange.started -= instance.OnLockOnChange;
             @LockOnChange.performed -= instance.OnLockOnChange;
             @LockOnChange.canceled -= instance.OnLockOnChange;
+            @CameraMove.started -= instance.OnCameraMove;
+            @CameraMove.performed -= instance.OnCameraMove;
+            @CameraMove.canceled -= instance.OnCameraMove;
         }
 
         /// <summary>
@@ -1602,6 +1656,13 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnLockOnChange(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "CameraMove" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnCameraMove(InputAction.CallbackContext context);
     }
     /// <summary>
     /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "UI" which allows adding and removing callbacks.

--- a/Assets/InputAction/PlayerInput.inputactions
+++ b/Assets/InputAction/PlayerInput.inputactions
@@ -77,6 +77,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": true
+                },
+                {
+                    "name": "CameraMove",
+                    "type": "Value",
+                    "id": "94015e16-3a8b-44c5-8018-03a1176872f7",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
                 }
             ],
             "bindings": [
@@ -464,6 +473,39 @@
                     "action": "LockOnChange",
                     "isComposite": false,
                     "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "983a713d-f5bf-40a7-8f56-1f2f9812dd37",
+                    "path": "<Mouse>/delta",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "CameraMove",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c1f763e4-925b-4ce4-a144-0c73e9a02c7a",
+                    "path": "<Gamepad>/rightStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "CameraMove",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "9c506375-7c54-48d1-94c3-a84d1dc9cd8e",
+                    "path": "<XInputController>/rightStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "CameraMove",
+                    "isComposite": false,
+                    "isPartOfComposite": false
                 }
             ]
         },

--- a/Assets/Prefab/System/Manager.prefab
+++ b/Assets/Prefab/System/Manager.prefab
@@ -751,7 +751,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PhaseManager
   _moviePlayer: {fileID: 3281229546311345012}
-  _firstSequence: 3
+  _firstSequence: 0
   _sequences:
   - rid: 6731506274227978447
   - rid: 6731506274227978448
@@ -781,6 +781,7 @@ MonoBehaviour:
         _skillSelectView: {fileID: 0}
         _skillSelectTimeLimit: 10
         _skillSelectCount: 3
+        _skillSelectStopTargetGroup: 48
         _nextSequence: 2
     - rid: 6731506274227978449
       type: {class: BossIntroMovieState, ns: , asm: Assembly-CSharp}
@@ -1189,6 +1190,8 @@ MonoBehaviour:
   _cameraDistance: 5
   _cameraHeight: 2
   _posSmoothTime: 0.2
+  _cameraRotationSpeed: {x: 30, y: 20}
+  _cameraInputDirection: {x: 1, y: -1}
   _lockOnAreaRadius: 150
   _lockOnPositionSpeed: 10
   _lockOnFollowSpeedMin: 1
@@ -1340,15 +1343,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.29603958
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.14262
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.12065983
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134265, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1379,6 +1382,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
+      propertyPath: m_ResetSeedOnPlay
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_InitialEventName
       value: create
       objectReference: {fileID: 0}
@@ -1388,39 +1395,39 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.x
-      value: 336.4163
+      value: 357.7636
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.y
-      value: 84.580956
+      value: 259.04453
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
-      value: 245.76157
+      value: 96.60663
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.x
-      value: -0.014827222
+      value: -0.0699569
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.y
-      value: 0.07325438
+      value: 0.75289166
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.z
-      value: 2.9958272
+      value: 0.01448657
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.x
-      value: 1
+      value: 1.0000002
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.y
-      value: 1.0000001
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.z
-      value: 1
+      value: 1.0000001
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1541,27 +1548,27 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 5903032592519319047, guid: 216edfa1ecb7b9c4f9ba31e4760ddf67, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.x
-      value: 336.4163
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5903032592519319047, guid: 216edfa1ecb7b9c4f9ba31e4760ddf67, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.y
-      value: 84.580956
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5903032592519319047, guid: 216edfa1ecb7b9c4f9ba31e4760ddf67, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
-      value: 245.76157
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5903032592519319047, guid: 216edfa1ecb7b9c4f9ba31e4760ddf67, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.x
-      value: -0.014827222
+      value: -0.29603958
       objectReference: {fileID: 0}
     - target: {fileID: 5903032592519319047, guid: 216edfa1ecb7b9c4f9ba31e4760ddf67, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.y
-      value: 0.07325438
+      value: 0.14262
       objectReference: {fileID: 0}
     - target: {fileID: 5903032592519319047, guid: 216edfa1ecb7b9c4f9ba31e4760ddf67, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.z
-      value: 2.9958272
+      value: 0.12065983
       objectReference: {fileID: 0}
     - target: {fileID: 5903032592519319047, guid: 216edfa1ecb7b9c4f9ba31e4760ddf67, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.x
@@ -1569,7 +1576,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5903032592519319047, guid: 216edfa1ecb7b9c4f9ba31e4760ddf67, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.y
-      value: 1.0000001
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5903032592519319047, guid: 216edfa1ecb7b9c4f9ba31e4760ddf67, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.z

--- a/Assets/Scripts/Camera/CameraManager.cs
+++ b/Assets/Scripts/Camera/CameraManager.cs
@@ -21,7 +21,7 @@ public class CameraManager : MonoBehaviour, ISpeedChange
     /// <summary>現在ロックオン中かどうか</summary>
     public bool IsLockedOn => _currentTarget != null;
 
-    public float TimeScale { get; set; } = 1f;
+    public float TimeScale => _timeScale;
 
     /// <summary>ロックオンエリアの半径（px）</summary>
     public float LockOnAreaRadius => _lockOnAreaRadius;
@@ -190,6 +190,7 @@ public class CameraManager : MonoBehaviour, ISpeedChange
     private Vector3 _blendStartPosition;
     private Quaternion _blendStartRotation;
 
+    private float _timeScale = 1f;
     #endregion
 
     #region イージング関数
@@ -260,7 +261,7 @@ public class CameraManager : MonoBehaviour, ISpeedChange
 
     public void OnSpeedChange(float scale)
     {
-        TimeScale = scale;
+        _timeScale = scale;
     }
 
     #endregion

--- a/Assets/Scripts/Camera/CameraManager.cs
+++ b/Assets/Scripts/Camera/CameraManager.cs
@@ -224,7 +224,10 @@ public class CameraManager : MonoBehaviour, ISpeedChange
         {
             _normalInputAxisController.enabled = false;
         }
+    }
 
+    private void Start()
+    {
         if (ServiceLocator.TryGet(out HitStopManager hitStopManager))
         {
             hitStopManager.Register(this, HitStopTargetGroup.Camera);

--- a/Assets/Scripts/Camera/CameraManager.cs
+++ b/Assets/Scripts/Camera/CameraManager.cs
@@ -295,7 +295,11 @@ public class CameraManager : MonoBehaviour, ISpeedChange
 
         float deltaTime = Time.fixedDeltaTime * TimeScale;
         _normalOrbitalFollow.HorizontalAxis.Value += rotationDelta.x * deltaTime;
-        _normalOrbitalFollow.VerticalAxis.Value += rotationDelta.y * deltaTime;
+        _normalOrbitalFollow.VerticalAxis.Value =
+            Mathf.Clamp(
+                _normalOrbitalFollow.VerticalAxis.Value + rotationDelta.y * deltaTime,
+                _normalOrbitalFollow.VerticalAxis.Range.x,
+                _normalOrbitalFollow.VerticalAxis.Range.y);
     }
 
     #endregion

--- a/Assets/Scripts/Camera/CameraManager.cs
+++ b/Assets/Scripts/Camera/CameraManager.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 /// 通常時の追従遅延およびロックオン時のターゲット追従を制御します。
 /// ターゲット選定はLockOnControllerに委譲しています。
 /// </summary>
-public class CameraManager : MonoBehaviour
+public class CameraManager : MonoBehaviour, ISpeedChange
 {
     #region パブリックプロパティ・イベント
 
@@ -20,6 +20,8 @@ public class CameraManager : MonoBehaviour
 
     /// <summary>現在ロックオン中かどうか</summary>
     public bool IsLockedOn => _currentTarget != null;
+
+    public float TimeScale { get; set; } = 1f;
 
     /// <summary>ロックオンエリアの半径（px）</summary>
     public float LockOnAreaRadius => _lockOnAreaRadius;
@@ -53,8 +55,14 @@ public class CameraManager : MonoBehaviour
         _cameraFollowTarget.position = _playerTransform.position;
         _normalCamera.Follow = _cameraFollowTarget;
 
+        if (ServiceLocator.TryGet(out HitStopManager hitStopManager))
+        {
+            hitStopManager.Register(this, HitStopTargetGroup.Camera);
+        }
+
         if (ServiceLocator.TryGet(out InputHandler inputHandler) && ServiceLocator.TryGet(out EnemyManager enemyManager))
         {
+            _inputHandler = inputHandler;
             _lockOnController.Init(this, inputHandler, enemyManager, _playerTransform);
         }
         else
@@ -136,6 +144,10 @@ public class CameraManager : MonoBehaviour
     [Tooltip("通常時のカメラ位置追従の遅延時間（秒）。大きいほど追従がゆっくりになる")]
     [SerializeField] private float _posSmoothTime = 0.2f;
 
+    [Header("フリーカメラ入力")]
+    [SerializeField] private Vector2 _cameraRotationSpeed = new(120f, 80f);
+    [SerializeField] private Vector2 _cameraInputDirection = new(1f, -1f);
+
     [Header("ロックオン設定")]
     [Tooltip("ターゲットがこの半径（px）内に収まっている間はカメラが回転しないデッドゾーン")]
     [SerializeField] private float _lockOnAreaRadius = 100f;
@@ -167,7 +179,9 @@ public class CameraManager : MonoBehaviour
     private Transform _playerTransform;
     private ILockOnTarget _currentTarget;
     private CinemachineOrbitalFollow _normalOrbitalFollow;
+    private CinemachineInputAxisController _normalInputAxisController;
     private Transform _cameraFollowTarget;
+    private InputHandler _inputHandler;
     private Vector3 _normalFollowVelocity;
     private CameraShake _cameraShake;
 
@@ -205,21 +219,45 @@ public class CameraManager : MonoBehaviour
         _lockOnCamera.Priority = _normalPriority - 1;
 
         _normalOrbitalFollow = _normalCamera.GetComponent<CinemachineOrbitalFollow>();
+        _normalInputAxisController = _normalCamera.GetComponent<CinemachineInputAxisController>();
+        if (_normalInputAxisController != null)
+        {
+            _normalInputAxisController.enabled = false;
+        }
+
+        if (ServiceLocator.TryGet(out HitStopManager hitStopManager))
+        {
+            hitStopManager.Register(this, HitStopTargetGroup.Camera);
+        }
     }
 
     private void FixedUpdate()
     {
         if (_playerTransform == null) return;
+        if (Mathf.Approximately(TimeScale, 0f)) return;
 
         if (IsLockedOn)
             UpdateLockOnCamera();
         else
+        {
+            UpdateFreeCameraRotation();
             UpdateNormalCameraPosition();
+        }
     }
 
     private void OnDestroy()
     {
+        if (ServiceLocator.TryGet(out HitStopManager hitStopManager))
+        {
+            hitStopManager.Unregister(this, HitStopTargetGroup.Camera);
+        }
+
         ServiceLocator.Unregister<CameraManager>();
+    }
+
+    public void OnSpeedChange(float scale)
+    {
+        TimeScale = scale;
     }
 
     #endregion
@@ -238,6 +276,23 @@ public class CameraManager : MonoBehaviour
             ref _normalFollowVelocity,
             _posSmoothTime
         );
+    }
+
+    private void UpdateFreeCameraRotation()
+    {
+        if (_normalOrbitalFollow == null || _inputHandler == null) return;
+
+        Vector2 input = _inputHandler.CameraMoveInput;
+        if (input.sqrMagnitude <= 0.0001f) return;
+
+        Vector2 rotationDelta = new(
+            input.x * _cameraInputDirection.x * _cameraRotationSpeed.x,
+            input.y * _cameraInputDirection.y * _cameraRotationSpeed.y
+        );
+
+        float deltaTime = Time.fixedDeltaTime * TimeScale;
+        _normalOrbitalFollow.HorizontalAxis.Value += rotationDelta.x * deltaTime;
+        _normalOrbitalFollow.VerticalAxis.Value += rotationDelta.y * deltaTime;
     }
 
     #endregion

--- a/Assets/Scripts/Data/HitStopData.cs
+++ b/Assets/Scripts/Data/HitStopData.cs
@@ -99,4 +99,5 @@ public enum HitStopTargetGroup
     AllEnemies = 1 << 2,  // 全敵（クリティカル用）
     Effects = 1 << 3,  // 戦闘エフェクト（環境VFX除く）
     Camera = 1 << 4,
+    ThunderGauge = 1 << 5,
 }

--- a/Assets/Scripts/EXP/EXPItem.cs
+++ b/Assets/Scripts/EXP/EXPItem.cs
@@ -7,14 +7,14 @@ public class EXPItem : MonoBehaviour, ISpeedChange, IPoolable
 
     public event Action<EXPItem> OnReleased;
 
-    public float TimeScale { get; set; } = 1f;
+    public float TimeScale => _timeScale;
 
     // ── IPoolable ────────────────────────────────────────────
 
     /// <summary>プールから取り出された直後。TimeScale を初期化する。</summary>
     public void OnGet()
     {
-        TimeScale = 1f;
+        _timeScale = 1f;
         OnReleased = null;
     }
 
@@ -55,8 +55,9 @@ public class EXPItem : MonoBehaviour, ISpeedChange, IPoolable
 
     public void OnSpeedChange(float scale)
     {
-        TimeScale = scale;
+        _timeScale = scale;
     }
 
     [SerializeField] private float _expValue;
+    private float _timeScale = 1f;
 }

--- a/Assets/Scripts/Effect/AureBuff/ThunderEffectView.cs
+++ b/Assets/Scripts/Effect/AureBuff/ThunderEffectView.cs
@@ -4,7 +4,7 @@ using UnityEngine.VFX;
 public class ThunderEffectView : MonoBehaviour, ISpeedChange
 {
     // ヒットストップ等で利用するタイムスケール
-    public float TimeScale { get; set; } = 1f;
+    public float TimeScale => _timeScale;
 
     /// <summary> プレイヤーのモードに応じたエフェクトの表示切り替え </summary>
     public void Play(PlayerMode mode)
@@ -22,7 +22,7 @@ public class ThunderEffectView : MonoBehaviour, ISpeedChange
 
     public void OnSpeedChange(float scale)
     {
-        TimeScale = scale;
+        _timeScale = scale;
         if (_vfx == null) return;
 
         // VFXの再生速度を直接更新する
@@ -31,6 +31,7 @@ public class ThunderEffectView : MonoBehaviour, ISpeedChange
 
     [SerializeField] private VisualEffect _vfx;
 
+    private float _timeScale = 1f;
     private void Awake()
     {
         if (_vfx == null) _vfx = GetComponent<VisualEffect>();

--- a/Assets/Scripts/Effect/LevelUp/LevelUpEffectView.cs
+++ b/Assets/Scripts/Effect/LevelUp/LevelUpEffectView.cs
@@ -6,7 +6,7 @@ using UnityEngine.VFX;
 
 public class LevelUpEffectView : MonoBehaviour, ISpeedChange
 {
-    public float TimeScale { get; set; } = 1f;
+    public float TimeScale => _timeScale;
 
     /// <summary>
     /// プレイヤーのステータスアップに応じたエフェクトを再生する
@@ -33,7 +33,7 @@ public class LevelUpEffectView : MonoBehaviour, ISpeedChange
 
     public void OnSpeedChange(float scale)
     {
-        TimeScale = scale;
+        _timeScale = scale;
 
         if (_vfx == null) return;
 
@@ -49,6 +49,8 @@ public class LevelUpEffectView : MonoBehaviour, ISpeedChange
 
     [SerializeField]
     private float _effectDuration = 1.5f;
+
+    private float _timeScale = 1f;
 
     private Dictionary<StatSkillType, LevelUpEffectData> _effectMap;
 

--- a/Assets/Scripts/Effect/PoolingEffect/EffectBase.cs
+++ b/Assets/Scripts/Effect/PoolingEffect/EffectBase.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 public abstract class EffectBase : MonoBehaviour, ISpeedChange, IPoolable
 {
     // ── プロパティ ─────────────────────────────────────────────
-    public float TimeScale { get; set; } = 1f;
+    public float TimeScale => _timeScale;
 
     // ── 公開 API ──────────────────────────────────────────────
 
@@ -45,7 +45,7 @@ public abstract class EffectBase : MonoBehaviour, ISpeedChange, IPoolable
     public virtual void OnRelease()
     {
         Stop();
-        TimeScale = 1f;
+        _timeScale = 1f;
         ApplyTimeScaleInternal(TimeScale);
         ApplyScaleInternal(Vector3.one);
     }
@@ -54,7 +54,7 @@ public abstract class EffectBase : MonoBehaviour, ISpeedChange, IPoolable
 
     public void OnSpeedChange(float scale)
     {
-        TimeScale = scale;
+        _timeScale = scale;
         ApplyTimeScaleInternal(TimeScale);
     }
 
@@ -81,4 +81,6 @@ public abstract class EffectBase : MonoBehaviour, ISpeedChange, IPoolable
     // ── Unity ライフサイクルフック (任意でオーバーライド可) ───
 
     protected virtual void Awake() { }
+
+    protected float _timeScale = 1f;
 }

--- a/Assets/Scripts/Effect/WeaponAuraEffect/WeaponEffectView.cs
+++ b/Assets/Scripts/Effect/WeaponAuraEffect/WeaponEffectView.cs
@@ -7,21 +7,13 @@ using UnityEngine.VFX;
 public class WeaponEffectView : MonoBehaviour, IWeaponEffect, ISpeedChange
 {
     // プロパティ実装
-    public float TimeScale
-    {
-        get => _timeScale;
-        set
-        {
-            _timeScale = value;
-            OnSpeedChange(_timeScale);
-        }
-    }
+    public float TimeScale => _timeScale;
 
     //開始時の処理
     public void Play()
     {
         gameObject.SetActive(true);
-        OnSpeedChange(_timeScale);
+        ApplySpeed();
     }
 
     // エフェクト停止時の処理
@@ -32,9 +24,15 @@ public class WeaponEffectView : MonoBehaviour, IWeaponEffect, ISpeedChange
 
     public void OnSpeedChange(float scale)
     {
+        _timeScale = scale;
+        ApplySpeed();
+    }
+
+    private void ApplySpeed()
+    {
         if (_vfx == null) return;
 
-        _vfx.playRate = scale;
+        _vfx.playRate = _timeScale;
     }
 
     private float _timeScale = 1f;

--- a/Assets/Scripts/Enemy/Boss/View/BossEnemyView.cs
+++ b/Assets/Scripts/Enemy/Boss/View/BossEnemyView.cs
@@ -60,11 +60,7 @@ namespace BossEnemy.View
         public bool IsBoss => true;
 
         /// <summary>HitStop等で使用するタイムスケール（DeadCondition の物理スケーリングに使用）</summary>
-        public float TimeScale
-        {
-            get { return _timeScale.Value; }
-            set { _timeScale.Value = value; }
-        }
+        public float TimeScale => _timeScale.Value;
 
         public IReadOnlyReactiveProperty<float> TimeScaleProperty => _timeScale;
 

--- a/Assets/Scripts/Enemy/Mob/Core/Enemy.cs
+++ b/Assets/Scripts/Enemy/Mob/Core/Enemy.cs
@@ -40,7 +40,7 @@ public abstract class Enemy : MonoBehaviour, IEnemy, ISpeedChange, IPoolable
 
     public virtual bool IsBoss => false;
 
-    public float TimeScale { get; set; } = 1f;
+    public float TimeScale => _timeScale;
 
     public bool IsDead => _isDead;
 
@@ -57,7 +57,7 @@ public abstract class Enemy : MonoBehaviour, IEnemy, ISpeedChange, IPoolable
     /// </summary>
     public void OnSpeedChange(float scale)
     {
-        TimeScale = scale;
+        _timeScale = scale;
         // HitStop中はアニメーション再生も停止させる
         _enemyAnimator?.SetAnimSpeed(scale);
     }
@@ -241,6 +241,8 @@ public abstract class Enemy : MonoBehaviour, IEnemy, ISpeedChange, IPoolable
 
     [SerializeField]private EnemyType _enemyType;
 
+    private float _timeScale = 1f;
+
     protected EnemyDefenseContext _defenceContext;
     protected EnemyStats _stats;
     protected Transform _playerTransform;
@@ -423,7 +425,7 @@ public abstract class Enemy : MonoBehaviour, IEnemy, ISpeedChange, IPoolable
         transform.position = spawnPosition;
         _isDead = false;
         _deadAnimationEnded = false;
-        TimeScale = 1f;
+        _timeScale = 1f;
 
         _stats.ResetHP(_data.MaxHP);
 

--- a/Assets/Scripts/Interface/ISpeedChange.cs
+++ b/Assets/Scripts/Interface/ISpeedChange.cs
@@ -2,6 +2,6 @@ using UnityEngine;
 
 public interface ISpeedChange
 {
-    float TimeScale { get; set; }
+    float TimeScale { get; }
     void OnSpeedChange(float scale);
 }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -16,7 +16,7 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
     public float CurrentThunderGauge => _playerStats.CurrentThunderGauge;
     public float BaseMaxThunderGauge => _playerStats.InitialMaxThunderGauge;
 
-    public float TimeScale { get; set; } = 1f;
+    public float TimeScale => _timeScale;
 
     public float BaseAttackPower => _playerData.AttackPower;
 
@@ -196,7 +196,7 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
 
     public void OnSpeedChange(float timeScale)
     {
-        TimeScale = timeScale;
+        _timeScale = timeScale;
         _playerAnimationController.SetAnimSpeed(timeScale);
         _move.SetTimeScale(timeScale);
     }
@@ -227,6 +227,7 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
 
     private CancellationTokenSource _damageInvincibilityCts;
 
+    private float _timeScale = 1f;
     private void Awake()
     {
         _playerStateManager = new PlayerStateManager();
@@ -384,14 +385,15 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
             _player = player;
         }
 
-        public float TimeScale { get; set; } = 1f;
+        public float TimeScale => _timeScale;
 
         public void OnSpeedChange(float scale)
         {
-            TimeScale = scale;
+            _timeScale = scale;
             _player._thunderGaugeTimeScale = scale;
         }
 
         private readonly Player _player;
+        private float _timeScale = 1f;
     }
 }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -85,7 +85,10 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
             this);
 
         if (ServiceLocator.TryGet(out HitStopManager hitStopManager))
+        {
             hitStopManager.Register(this, HitStopTargetGroup.Player);
+            hitStopManager.Register(_thunderGaugeSpeedTarget, HitStopTargetGroup.ThunderGauge);
+        }
 
         _interactor?.SearchLoop(destroyCancellationToken).Forget();
     }
@@ -216,6 +219,8 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
 
     private PlayerStateManager _playerStateManager;
     private PlayerStats _playerStats;
+    private float _thunderGaugeTimeScale = 1f;
+    private ThunderGaugeSpeedTarget _thunderGaugeSpeedTarget;
 
     private List<IDamageReactionModifier> _damageReactionModifiers = new List<IDamageReactionModifier>();
     private List<IDamageModifier> _damageModifiers = new List<IDamageModifier>();
@@ -226,6 +231,7 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
     {
         _playerStateManager = new PlayerStateManager();
         _playerStats = new PlayerStats(_playerData);
+        _thunderGaugeSpeedTarget = new ThunderGaugeSpeedTarget(this);
     }
 
     private void Update()
@@ -239,7 +245,10 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
             cameraManager.OnLockOnTargetChanged -= SetLockOnTarget;
 
         if (ServiceLocator.TryGet(out HitStopManager hitStopManager))
+        {
             hitStopManager.Unregister(this, HitStopTargetGroup.Player);
+            hitStopManager.Unregister(_thunderGaugeSpeedTarget, HitStopTargetGroup.ThunderGauge);
+        }
 
         if (_playerStats != null)
         {
@@ -286,7 +295,7 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
         bool isThunderMode = _modeController != null
             && _modeController.CurrentMode == PlayerMode.Thunder
             && _playerStateManager.CurrentState != PlayerState.ModeChanging;
-        _playerStats.TickThunderGauge(Time.deltaTime * TimeScale, isThunderMode);
+        _playerStats.TickThunderGauge(Time.deltaTime * TimeScale * _thunderGaugeTimeScale, isThunderMode);
     }
 
     /// <summary>
@@ -366,5 +375,23 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
     {
         _playerStateManager.ChangeState(PlayerState.Dead);
         OnDead?.Invoke();
+    }
+
+    private sealed class ThunderGaugeSpeedTarget : ISpeedChange
+    {
+        public ThunderGaugeSpeedTarget(Player player)
+        {
+            _player = player;
+        }
+
+        public float TimeScale { get; set; } = 1f;
+
+        public void OnSpeedChange(float scale)
+        {
+            TimeScale = scale;
+            _player._thunderGaugeTimeScale = scale;
+        }
+
+        private readonly Player _player;
     }
 }

--- a/Assets/Scripts/Sequence/State/MobAndSkillState.cs
+++ b/Assets/Scripts/Sequence/State/MobAndSkillState.cs
@@ -89,6 +89,7 @@ public class MobAndSkillState : ISequenceState
 
         _skillSelectPresenter?.Dispose();
         _skillSelectPresenter = null;
+        ReleaseSkillSelectHitStop();
 
         _mobBattleTimerPresenter?.Dispose();
         _mobBattleTimerPresenter = null;
@@ -122,6 +123,9 @@ public class MobAndSkillState : ISequenceState
     [SerializeField] private SkillSelectView _skillSelectView;
     [SerializeField] private float _skillSelectTimeLimit = 10f;
     [SerializeField] private int _skillSelectCount = 3;
+    [SerializeField] private HitStopTargetGroup _skillSelectStopTargetGroup =
+        HitStopTargetGroup.Camera |
+        HitStopTargetGroup.ThunderGauge;
 
     [Header("シークエンス設定")]
     [SerializeField] private SequenceStateType _nextSequence = SequenceStateType.BossIntroMovie;
@@ -143,6 +147,7 @@ public class MobAndSkillState : ISequenceState
     private CountDownTimerPresenter _mobBattleTimerPresenter;
     private CountDownTimerPresenter _skillSelectTimerPresenter;
     private SequenceStatusPresenter _sequenceStatusPresenter;
+    private IDisposable _skillSelectHitStopHandle;
 
     private bool _waveCleared;
     private bool _timeUpFlag;
@@ -300,8 +305,9 @@ public class MobAndSkillState : ISequenceState
         _isSkillSelected = false;
         _skillSelectTimeUp = false;
 
-        // 世界を止める
+        // フリーカメラと雷神ゲージだけを止める
         _mobBattleTimer.PauseTimer();
+        BeginSkillSelectHitStop();
         context.InputHandler?.EnableInput(false);
         ShowCursor();
 
@@ -344,8 +350,9 @@ public class MobAndSkillState : ISequenceState
 
         _skillSelectPresenter?.Dispose();
         _skillSelectPresenter = null;
+        ReleaseSkillSelectHitStop();
 
-        // 世界を再開
+        // フリーカメラと雷神ゲージを再開
         _mobBattleTimer.ResumeTimer();
         context.InputHandler?.EnableInput(true);
         HideCursor();
@@ -360,6 +367,24 @@ public class MobAndSkillState : ISequenceState
     {
         _skillSelectPresenter?.AutoSelect();
         EndSkillSelect(context);
+    }
+
+    private void BeginSkillSelectHitStop()
+    {
+        ReleaseSkillSelectHitStop();
+
+        if (!ServiceLocator.TryGet(out HitStopManager hitStopManager))
+        {
+            return;
+        }
+
+        _skillSelectHitStopHandle = hitStopManager.BeginManualStop(_skillSelectStopTargetGroup);
+    }
+
+    private void ReleaseSkillSelectHitStop()
+    {
+        _skillSelectHitStopHandle?.Dispose();
+        _skillSelectHitStopHandle = null;
     }
 
     private static void HideCursor()

--- a/Assets/Scripts/System/HitStopManager.cs
+++ b/Assets/Scripts/System/HitStopManager.cs
@@ -123,13 +123,27 @@ public sealed class HitStopManager : IDisposable
         ).Forget();
     }
 
+    public IDisposable BeginManualStop(
+       HitStopTargetGroup targetGroup,
+       float timeScale = 0f,
+       int priority = int.MinValue,
+       IReadOnlyList<ISpeedChange> hitEnemyTargets = null)
+    {
+        var stop = new ManualStop(targetGroup, timeScale, priority, hitEnemyTargets);
+        _manualStops.Add(stop);
+        ApplyResolvedSpeedScale(targetGroup);
+
+        return new ManualStopHandle(this, stop);
+    }
+
     /// <summary>
     /// 現在発動中のヒットストップを即時キャンセルし、速度を元に戻す
     /// </summary>
     public void Cancel()
     {
         _hitStopCancellation?.Cancel();
-        ApplySpeedScale(1f, ~HitStopTargetGroup.None, null);
+        _manualStops.Clear();
+        ApplyTimedSpeedScale(1f, ~HitStopTargetGroup.None, null);
     }
 
     /// <summary>
@@ -146,6 +160,8 @@ public sealed class HitStopManager : IDisposable
             list.Clear();
         }
 
+        _manualStops.Clear();
+
         ServiceLocator.Unregister<HitStopManager>();
     }
 
@@ -160,6 +176,7 @@ public sealed class HitStopManager : IDisposable
             { HitStopTargetGroup.AllEnemies, new List<ISpeedChange>() },
             { HitStopTargetGroup.Effects,    new List<ISpeedChange>() },
             { HitStopTargetGroup.Camera,     new List<ISpeedChange>() },
+            { HitStopTargetGroup.ThunderGauge, new List<ISpeedChange>() },
         };
 
     /// <summary>
@@ -173,7 +190,21 @@ public sealed class HitStopManager : IDisposable
         { HitStopTargetGroup.AllEnemies, 1f },
         { HitStopTargetGroup.Effects,    1f },
         { HitStopTargetGroup.Camera,     1f },
+        { HitStopTargetGroup.ThunderGauge, 1f },
         };
+
+    private readonly Dictionary<HitStopTargetGroup, float> _timedScale =
+        new()
+        {
+        { HitStopTargetGroup.Player,     1f },
+        { HitStopTargetGroup.HitEnemy,   1f },
+        { HitStopTargetGroup.AllEnemies, 1f },
+        { HitStopTargetGroup.Effects,    1f },
+        { HitStopTargetGroup.Camera,     1f },
+        { HitStopTargetGroup.ThunderGauge, 1f },
+        };
+
+    private readonly List<ManualStop> _manualStops = new();
 
     /// <summary>
     /// 現在発動中のヒットストップ用キャンセルトークン
@@ -181,6 +212,7 @@ public sealed class HitStopManager : IDisposable
     private CancellationTokenSource _hitStopCancellation;
 
     private HashSet<ISpeedChange> _activeHitEnemyTargets;
+    private IReadOnlyList<ISpeedChange> _timedHitEnemyTargets;
 
     private int _currentPriority = int.MaxValue;
 
@@ -209,7 +241,7 @@ public sealed class HitStopManager : IDisposable
         var cancellation = new CancellationTokenSource();
         _hitStopCancellation = cancellation;
 
-        ApplySpeedScale(timeScale, targetGroups, hitEnemyTargets);
+        ApplyTimedSpeedScale(timeScale, targetGroups, hitEnemyTargets);
 
         try
         {
@@ -226,7 +258,7 @@ public sealed class HitStopManager : IDisposable
         {
             if (ReferenceEquals(_hitStopCancellation, cancellation))
             {
-                ApplySpeedScale(1f, targetGroups, hitEnemyTargets);
+                ApplyTimedSpeedScale(1f, targetGroups, hitEnemyTargets);
 
                 _currentPriority = int.MaxValue;
 
@@ -239,6 +271,137 @@ public sealed class HitStopManager : IDisposable
     /// <summary>
     /// 指定グループの ISpeedChange に速度変更を適用する
     /// </summary>
+    private void ApplyTimedSpeedScale(
+    float scale,
+    HitStopTargetGroup targetGroups,
+    IReadOnlyList<ISpeedChange> hitEnemyTargets)
+    {
+        foreach (var group in _groupTargets.Keys.ToArray())
+        {
+            if ((targetGroups & group) == 0) continue;
+
+            _timedScale[group] = scale;
+        }
+
+        if ((targetGroups & HitStopTargetGroup.HitEnemy) != 0)
+        {
+            _timedHitEnemyTargets = Mathf.Abs(scale - 1f) > 0.0001f
+                ? hitEnemyTargets
+                : null;
+        }
+
+        ApplyResolvedSpeedScale(targetGroups);
+    }
+
+    private void ApplyResolvedSpeedScale(HitStopTargetGroup targetGroups)
+    {
+        foreach (var (group, list) in _groupTargets)
+        {
+            if ((targetGroups & group) == 0) continue;
+
+            var manualStop = GetActiveManualStop(group);
+            float scale = manualStop?.TimeScale ?? _timedScale[group];
+
+            _currentScale[group] = scale;
+
+            if (group == HitStopTargetGroup.HitEnemy)
+            {
+                _activeHitEnemyTargets =
+                (Mathf.Abs(scale - 1f) > 0.0001f && manualStop?.HitEnemyTargets != null)
+                    ? new HashSet<ISpeedChange>(manualStop.HitEnemyTargets)
+                    : (Mathf.Abs(scale - 1f) > 0.0001f && _timedHitEnemyTargets != null)
+                    ? new HashSet<ISpeedChange>(_timedHitEnemyTargets)
+                    : null;
+            }
+
+            foreach (var target in list.ToArray())
+            {
+                if (group == HitStopTargetGroup.HitEnemy &&
+                    _activeHitEnemyTargets != null &&
+                    !_activeHitEnemyTargets.Contains(target))
+                {
+                    continue;
+                }
+
+                target.OnSpeedChange(scale);
+            }
+        }
+    }
+
+    private ManualStop GetActiveManualStop(HitStopTargetGroup group)
+    {
+        ManualStop activeStop = null;
+
+        foreach (var stop in _manualStops)
+        {
+            if ((stop.TargetGroup & group) == 0)
+            {
+                continue;
+            }
+
+            if (activeStop == null || stop.Priority < activeStop.Priority)
+            {
+                activeStop = stop;
+            }
+        }
+
+        return activeStop;
+    }
+
+    private void EndManualStop(ManualStop stop)
+    {
+        if (stop == null || !_manualStops.Remove(stop))
+        {
+            return;
+        }
+
+        ApplyResolvedSpeedScale(stop.TargetGroup);
+    }
+
+    private sealed class ManualStop
+    {
+        public ManualStop(
+            HitStopTargetGroup targetGroup,
+            float timeScale,
+            int priority,
+            IReadOnlyList<ISpeedChange> hitEnemyTargets)
+        {
+            TargetGroup = targetGroup;
+            TimeScale = timeScale;
+            Priority = priority;
+            HitEnemyTargets = hitEnemyTargets;
+        }
+
+        public HitStopTargetGroup TargetGroup { get; }
+        public float TimeScale { get; }
+        public int Priority { get; }
+        public IReadOnlyList<ISpeedChange> HitEnemyTargets { get; }
+    }
+
+    private sealed class ManualStopHandle : IDisposable
+    {
+        public ManualStopHandle(HitStopManager owner, ManualStop stop)
+        {
+            _owner = owner;
+            _stop = stop;
+        }
+
+        public void Dispose()
+        {
+            if (_owner == null)
+            {
+                return;
+            }
+
+            _owner.EndManualStop(_stop);
+            _owner = null;
+            _stop = null;
+        }
+
+        private HitStopManager _owner;
+        private ManualStop _stop;
+    }
+
     private void ApplySpeedScale(
     float scale,
     HitStopTargetGroup targetGroups,

--- a/Assets/Scripts/System/InputHandler.cs
+++ b/Assets/Scripts/System/InputHandler.cs
@@ -5,6 +5,7 @@ using UnityEngine.InputSystem;
 public class InputHandler : MonoBehaviour
 {
     public Vector2 MoveInput { get; private set; }
+    public Vector2 CameraMoveInput { get; private set; }
 
     // イベント
     public event Action OnDodge;
@@ -31,6 +32,8 @@ public class InputHandler : MonoBehaviour
         else
         {
             _isDisablingInput = true;
+            MoveInput = Vector2.zero;
+            CameraMoveInput = Vector2.zero;
             _input.Player.Disable();
         }
     }
@@ -50,6 +53,9 @@ public class InputHandler : MonoBehaviour
         // 移動
         _input.Player.Move.performed += ctx => MoveInput = ctx.ReadValue<Vector2>();
         _input.Player.Move.canceled += _ => MoveInput = Vector2.zero;
+
+        _input.Player.CameraMove.performed += OnCameraMovePerformed;
+        _input.Player.CameraMove.canceled += OnCameraMoveCanceled;
 
         // 回避
         _input.Player.Dodge.started += _ => OnDodge?.Invoke();
@@ -87,6 +93,9 @@ public class InputHandler : MonoBehaviour
     private void OnDisable()
     {
         EnableInput(false);
+
+        _input.Player.CameraMove.performed -= OnCameraMovePerformed;
+        _input.Player.CameraMove.canceled -= OnCameraMoveCanceled;
     }
 
     private void OnDestroy()
@@ -95,5 +104,15 @@ public class InputHandler : MonoBehaviour
         {
             ServiceLocator.Unregister<InputHandler>();
         }
+    }
+
+    private void OnCameraMovePerformed(InputAction.CallbackContext context)
+    {
+        CameraMoveInput = context.ReadValue<Vector2>();
+    }
+
+    private void OnCameraMoveCanceled(InputAction.CallbackContext _)
+    {
+        CameraMoveInput = Vector2.zero;
     }
 }


### PR DESCRIPTION
フリールックのカメラの回転がありえないくらい早くなってしまっているが、そこの修正は後ほどおこなう

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * カメラ移動用の入力「CameraMove」を追加し、マウスの移動量やゲームパッドの右スティックでカメラ操作に対応。
  * スキル選択中に手動ヒットストップ演出を追加し、対象にカメラや雷ゲージを指定可能に。
* **改善**
  * 手動停止と時間指定のヒットストップを統合し、優先度付きで制御できるよう強化。
  * 雷ゲージの速度変化を調整し、演出全体のタイミングを最適化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->