### PR TITLE
ジャスト回避を雷神モードの専用能力に変更

### DIFF
--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -108,7 +108,9 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
     {
         if (_playerStateManager.IsDead()) return;
 
-        if (_justDodgeSystem != null && _justDodgeSystem.TryJustDodge())
+        if (CurrentMode == PlayerMode.Thunder
+            && _justDodgeSystem != null
+            && _justDodgeSystem.TryJustDodge())
         {
             Debug.Log("ジャスト回避成功");
             return;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * ジャスト回避が成功する条件を調整し、Thunderモード中のみ発動するようにしました。
  * その他のモードでは、ジャスト回避によってダメージを無効化できなくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->