### PR TITLE
闘神モードの範囲エフェクト

### DIFF
--- a/Assets/Data/PlayerData/AttackData/ThunderCombo1.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderCombo1.asset
@@ -44,6 +44,15 @@ MonoBehaviour:
         _amplitude: 1
         _frequency: 2
         _duration: 0.1
+      AttackEffect:
+        _enabled: 0
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 90, z: 0}
+        _localScale: {x: 1, y: 1, z: 1}
+        _previewPrefab: {fileID: 0}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40

--- a/Assets/Data/PlayerData/AttackData/ThunderCombo2.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderCombo2.asset
@@ -48,6 +48,15 @@ MonoBehaviour:
         _amplitude: 1
         _frequency: 2
         _duration: 0.1
+      AttackEffect:
+        _enabled: 0
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 90, z: 0}
+        _localScale: {x: 1, y: 1, z: 1}
+        _previewPrefab: {fileID: 0}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40

--- a/Assets/Data/PlayerData/AttackData/ThunderCombo3.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderCombo3.asset
@@ -46,6 +46,15 @@ MonoBehaviour:
         _amplitude: 1
         _frequency: 2
         _duration: 0.1
+      AttackEffect:
+        _enabled: 0
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 90, z: 0}
+        _localScale: {x: 1, y: 1, z: 1}
+        _previewPrefab: {fileID: 0}
     - DamageMultiplier: 1.2
       AttackRange: 1
       AttackRadius: 1
@@ -70,6 +79,15 @@ MonoBehaviour:
         _amplitude: 0
         _frequency: 0
         _duration: 0
+      AttackEffect:
+        _enabled: 1
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 90, z: 0}
+        _localScale: {x: 1, y: 1, z: 1}
+        _previewPrefab: {fileID: 0}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40

--- a/Assets/Data/PlayerData/AttackData/ThunderCombo4.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderCombo4.asset
@@ -50,6 +50,15 @@ MonoBehaviour:
         _amplitude: 1
         _frequency: 2
         _duration: 0.1
+      AttackEffect:
+        _enabled: 0
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 90, z: 0}
+        _localScale: {x: 1, y: 1, z: 1}
+        _previewPrefab: {fileID: 0}
     - DamageMultiplier: 1.2
       AttackRange: 1
       AttackRadius: 1
@@ -78,6 +87,15 @@ MonoBehaviour:
         _amplitude: 1
         _frequency: 2
         _duration: 0.1
+      AttackEffect:
+        _enabled: 1
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 90, z: 0}
+        _localScale: {x: 1, y: 1, z: 1}
+        _previewPrefab: {fileID: 0}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40

--- a/Assets/Data/PlayerData/AttackData/ThunderCombo5.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderCombo5.asset
@@ -48,6 +48,15 @@ MonoBehaviour:
         _amplitude: 1
         _frequency: 2
         _duration: 0.15
+      AttackEffect:
+        _enabled: 0
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 90, z: 0}
+        _localScale: {x: 1, y: 1, z: 1}
+        _previewPrefab: {fileID: 0}
     _enableHoming: 1
     _homingRadius: 10
     _homingAngle: 45

--- a/Assets/Data/PlayerData/AttackData/ThunderCombo6.asset
+++ b/Assets/Data/PlayerData/AttackData/ThunderCombo6.asset
@@ -50,6 +50,15 @@ MonoBehaviour:
         _amplitude: 1.5
         _frequency: 2.5
         _duration: 0.15
+      AttackEffect:
+        _enabled: 0
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 90, z: 0}
+        _localScale: {x: 1, y: 1, z: 1}
+        _previewPrefab: {fileID: 0}
     _enableHoming: 1
     _homingRadius: 10
     _homingAngle: 45

--- a/Assets/Data/PlayerData/AttackData/WarriorCombo1.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorCombo1.asset
@@ -47,7 +47,7 @@ MonoBehaviour:
         _effectKey: WarriorPiercingEarth
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
-        _localScale: {x: 1, y: 1, z: 1}
+        _localScale: {x: -4.32, y: 1, z: 1}
         _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 5
@@ -133,6 +133,8 @@ MonoBehaviour:
         _effectKey: WarriorPiercingEarth
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
         _localScale: {x: 4.47, y: 1, z: 0.28}
         _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
@@ -219,6 +221,8 @@ MonoBehaviour:
         _effectKey: WarriorPiercingEarth
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
         _localScale: {x: 5.89, y: 1, z: 0.28}
         _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
@@ -305,6 +309,8 @@ MonoBehaviour:
         _effectKey: WarriorPiercingEarth
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
         _localScale: {x: 6.89, y: 1, z: 0.27}
         _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1

--- a/Assets/Data/PlayerData/AttackData/WarriorCombo1.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorCombo1.asset
@@ -45,8 +45,6 @@ MonoBehaviour:
       AttackEffect:
         _enabled: 0
         _effectKey: WarriorPiercingEarth
-        _fitToAttackArea: 1
-        _baseSize: {x: 10, y: 2, z: 2}
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
         _localScale: {x: 1, y: 1, z: 1}
@@ -133,8 +131,6 @@ MonoBehaviour:
       AttackEffect:
         _enabled: 1
         _effectKey: WarriorPiercingEarth
-        _fitToAttackArea: 1
-        _baseSize: {x: 10, y: 2, z: 2}
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
         _localScale: {x: 4.47, y: 1, z: 0.28}
@@ -221,8 +217,6 @@ MonoBehaviour:
       AttackEffect:
         _enabled: 1
         _effectKey: WarriorPiercingEarth
-        _fitToAttackArea: 1
-        _baseSize: {x: 10, y: 2, z: 2}
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
         _localScale: {x: 5.89, y: 1, z: 0.28}
@@ -309,8 +303,6 @@ MonoBehaviour:
       AttackEffect:
         _enabled: 1
         _effectKey: WarriorPiercingEarth
-        _fitToAttackArea: 1
-        _baseSize: {x: 10, y: 2, z: 2}
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
         _localScale: {x: 6.89, y: 1, z: 0.27}

--- a/Assets/Data/PlayerData/AttackData/WarriorCombo1.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorCombo1.asset
@@ -42,6 +42,15 @@ MonoBehaviour:
         _amplitude: 1.5
         _frequency: 2.5
         _duration: 0.15
+      AttackEffect:
+        _enabled: 0
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 0, z: 0}
+        _localScale: {x: 1, y: 1, z: 1}
+        _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40
@@ -121,6 +130,15 @@ MonoBehaviour:
         _amplitude: 2
         _frequency: 3
         _duration: 0.2
+      AttackEffect:
+        _enabled: 1
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 0, z: 0}
+        _localScale: {x: 4.47, y: 1, z: 0.28}
+        _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40
@@ -200,6 +218,15 @@ MonoBehaviour:
         _amplitude: 2.8
         _frequency: 3.5
         _duration: 0.24
+      AttackEffect:
+        _enabled: 1
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 0, z: 0}
+        _localScale: {x: 5.89, y: 1, z: 0.28}
+        _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40
@@ -279,6 +306,15 @@ MonoBehaviour:
         _amplitude: 3.2
         _frequency: 3.8
         _duration: 0.3
+      AttackEffect:
+        _enabled: 1
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 0, z: 0}
+        _localScale: {x: 6.89, y: 1, z: 0.27}
+        _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40

--- a/Assets/Data/PlayerData/AttackData/WarriorCombo2.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorCombo2.asset
@@ -133,6 +133,8 @@ MonoBehaviour:
         _effectKey: WarriorPiercingEarth
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
         _localScale: {x: 7.91, y: 1, z: 0.26}
         _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
@@ -219,6 +221,8 @@ MonoBehaviour:
         _effectKey: WarriorPiercingEarth
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
         _localScale: {x: 6.08, y: 1, z: 0.25}
         _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
@@ -305,6 +309,8 @@ MonoBehaviour:
         _effectKey: WarriorPiercingEarth
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
         _localScale: {x: 6.33, y: 1, z: 0.27}
         _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1

--- a/Assets/Data/PlayerData/AttackData/WarriorCombo2.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorCombo2.asset
@@ -45,8 +45,6 @@ MonoBehaviour:
       AttackEffect:
         _enabled: 0
         _effectKey: WarriorPiercingEarth
-        _fitToAttackArea: 1
-        _baseSize: {x: 10, y: 2, z: 2}
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 90, z: 0}
         _localScale: {x: 1, y: 1, z: 1}
@@ -133,8 +131,6 @@ MonoBehaviour:
       AttackEffect:
         _enabled: 1
         _effectKey: WarriorPiercingEarth
-        _fitToAttackArea: 1
-        _baseSize: {x: 10, y: 2, z: 2}
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
         _localScale: {x: 7.91, y: 1, z: 0.26}
@@ -221,8 +217,6 @@ MonoBehaviour:
       AttackEffect:
         _enabled: 1
         _effectKey: WarriorPiercingEarth
-        _fitToAttackArea: 1
-        _baseSize: {x: 10, y: 2, z: 2}
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
         _localScale: {x: 6.08, y: 1, z: 0.25}
@@ -309,8 +303,6 @@ MonoBehaviour:
       AttackEffect:
         _enabled: 1
         _effectKey: WarriorPiercingEarth
-        _fitToAttackArea: 1
-        _baseSize: {x: 10, y: 2, z: 2}
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
         _localScale: {x: 6.33, y: 1, z: 0.27}

--- a/Assets/Data/PlayerData/AttackData/WarriorCombo2.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorCombo2.asset
@@ -42,6 +42,15 @@ MonoBehaviour:
         _amplitude: 1.5
         _frequency: 2.5
         _duration: 0.15
+      AttackEffect:
+        _enabled: 0
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 90, z: 0}
+        _localScale: {x: 1, y: 1, z: 1}
+        _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 45
@@ -121,6 +130,15 @@ MonoBehaviour:
         _amplitude: 2
         _frequency: 3
         _duration: 0.2
+      AttackEffect:
+        _enabled: 1
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 0, z: 0}
+        _localScale: {x: 7.91, y: 1, z: 0.26}
+        _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40
@@ -200,6 +218,15 @@ MonoBehaviour:
         _amplitude: 2.8
         _frequency: 3.5
         _duration: 0.24
+      AttackEffect:
+        _enabled: 1
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 0, z: 0}
+        _localScale: {x: 6.08, y: 1, z: 0.25}
+        _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40
@@ -279,6 +306,15 @@ MonoBehaviour:
         _amplitude: 3.2
         _frequency: 3.8
         _duration: 0.3
+      AttackEffect:
+        _enabled: 1
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 0, z: 0}
+        _localScale: {x: 6.33, y: 1, z: 0.27}
+        _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40

--- a/Assets/Data/PlayerData/AttackData/WarriorCombo3.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorCombo3.asset
@@ -133,6 +133,8 @@ MonoBehaviour:
         _effectKey: WarriorPiercingEarth
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
         _localScale: {x: 5.38, y: 1, z: 0.23}
         _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
@@ -219,6 +221,8 @@ MonoBehaviour:
         _effectKey: WarriorPiercingEarth
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
         _localScale: {x: 4.89, y: 1, z: 0.24}
         _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
@@ -305,6 +309,8 @@ MonoBehaviour:
         _effectKey: WarriorPiercingEarth
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
         _localScale: {x: 5.32, y: 1, z: 0.23}
         _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1

--- a/Assets/Data/PlayerData/AttackData/WarriorCombo3.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorCombo3.asset
@@ -42,6 +42,15 @@ MonoBehaviour:
         _amplitude: 1.5
         _frequency: 2.5
         _duration: 0.15
+      AttackEffect:
+        _enabled: 0
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 0, z: 0}
+        _localScale: {x: 1, y: 1, z: 1}
+        _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40
@@ -121,6 +130,15 @@ MonoBehaviour:
         _amplitude: 2
         _frequency: 3
         _duration: 0.2
+      AttackEffect:
+        _enabled: 1
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 0, z: 0}
+        _localScale: {x: 5.38, y: 1, z: 0.23}
+        _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40
@@ -200,6 +218,15 @@ MonoBehaviour:
         _amplitude: 2.8
         _frequency: 3.5
         _duration: 0.24
+      AttackEffect:
+        _enabled: 1
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 0, z: 0}
+        _localScale: {x: 4.89, y: 1, z: 0.24}
+        _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 5
     _homingAngle: 40
@@ -279,6 +306,15 @@ MonoBehaviour:
         _amplitude: 3.2
         _frequency: 3.8
         _duration: 0.3
+      AttackEffect:
+        _enabled: 1
+        _effectKey: WarriorPiercingEarth
+        _fitToAttackArea: 1
+        _baseSize: {x: 10, y: 2, z: 2}
+        _localPosition: {x: 0, y: 0.05, z: 0}
+        _localEulerAngles: {x: 0, y: 0, z: 0}
+        _localScale: {x: 5.32, y: 1, z: 0.23}
+        _previewPrefab: {fileID: 6100000000000000001, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
     _enableHoming: 1
     _homingRadius: 10
     _homingAngle: 45

--- a/Assets/Data/PlayerData/AttackData/WarriorCombo3.asset
+++ b/Assets/Data/PlayerData/AttackData/WarriorCombo3.asset
@@ -45,8 +45,6 @@ MonoBehaviour:
       AttackEffect:
         _enabled: 0
         _effectKey: WarriorPiercingEarth
-        _fitToAttackArea: 1
-        _baseSize: {x: 10, y: 2, z: 2}
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
         _localScale: {x: 1, y: 1, z: 1}
@@ -133,8 +131,6 @@ MonoBehaviour:
       AttackEffect:
         _enabled: 1
         _effectKey: WarriorPiercingEarth
-        _fitToAttackArea: 1
-        _baseSize: {x: 10, y: 2, z: 2}
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
         _localScale: {x: 5.38, y: 1, z: 0.23}
@@ -221,8 +217,6 @@ MonoBehaviour:
       AttackEffect:
         _enabled: 1
         _effectKey: WarriorPiercingEarth
-        _fitToAttackArea: 1
-        _baseSize: {x: 10, y: 2, z: 2}
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
         _localScale: {x: 4.89, y: 1, z: 0.24}
@@ -309,8 +303,6 @@ MonoBehaviour:
       AttackEffect:
         _enabled: 1
         _effectKey: WarriorPiercingEarth
-        _fitToAttackArea: 1
-        _baseSize: {x: 10, y: 2, z: 2}
         _localPosition: {x: 0, y: 0.05, z: 0}
         _localEulerAngles: {x: 0, y: 0, z: 0}
         _localScale: {x: 5.32, y: 1, z: 0.23}

--- a/Assets/Editor/AttackDataEditor.cs
+++ b/Assets/Editor/AttackDataEditor.cs
@@ -22,6 +22,8 @@ public class AttackDataEditor : Editor
     private bool _isAutoTarget = true;
     private Vector3 _previewDirection = Vector3.forward;
     private float _previewAngle;
+    private GameObject _effectPreviewInstance;
+    private EffectTransformTool _effectTransformTool = EffectTransformTool.Move;
 
     private static readonly Color AttackSphereColor = new(1f, 0.3f, 0.3f, 0.25f);
     private static readonly Color AttackSphereOutline = new(1f, 0.2f, 0.2f, 0.9f);
@@ -48,6 +50,7 @@ public class AttackDataEditor : Editor
     private void OnDisable()
     {
         SceneView.duringSceneGui -= HandleSceneGUI;
+        DestroyEffectPreview();
     }
 
     public override void OnInspectorGUI()
@@ -217,6 +220,7 @@ public class AttackDataEditor : Editor
             }
 
             DrawPreviewTargetField();
+            DrawEffectPreviewControls();
 
             if (_previewTarget == null)
             {
@@ -233,7 +237,7 @@ public class AttackDataEditor : Editor
     {
         EditorGUILayout.BeginHorizontal();
         EditorGUI.BeginChangeCheck();
-        _previewTarget = (GameObject)EditorGUILayout.ObjectField("Target", _previewTarget, typeof(GameObject), true);
+        _previewTarget = (GameObject)EditorGUILayout.ObjectField("Reference Object", _previewTarget, typeof(GameObject), true);
         if (EditorGUI.EndChangeCheck())
             _isAutoTarget = false;
 
@@ -243,6 +247,18 @@ public class AttackDataEditor : Editor
             TryAutoFindTarget();
         }
         EditorGUILayout.EndHorizontal();
+    }
+
+    private void DrawEffectPreviewControls()
+    {
+        var effect = GetSelectedEffect();
+        if (effect == null) return;
+
+        EditorGUILayout.Space(3);
+        EditorGUILayout.LabelField("Effect Preview", EditorStyles.miniBoldLabel);
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_previewPrefab"), new GUIContent("Target Object"));
+        if (GUILayout.Button("Open Attack Effect Layout Editor", GUILayout.Height(26)))
+            AttackEffectLayoutWindow.Open((AttackData)target, _selectedVariantIndex);
     }
 
     private void DrawLegend()
@@ -293,6 +309,8 @@ public class AttackDataEditor : Editor
             int index = Mathf.Clamp(_selectedVariantIndex, 0, variants.arraySize - 1);
             DrawVariantPreview(pivot, dir, variants.GetArrayElementAtIndex(index));
         }
+
+        DrawEffectTransformHandle(pivot, dir);
     }
 
     private static void DrawVariantPreview(Vector3 pivot, Vector3 dir, SerializedProperty variant)
@@ -380,6 +398,95 @@ public class AttackDataEditor : Editor
     {
         if (_variants == null || _variants.arraySize == 0) return null;
         return _variants.GetArrayElementAtIndex(Mathf.Clamp(_selectedVariantIndex, 0, _variants.arraySize - 1));
+    }
+
+    private SerializedProperty GetSelectedEffect()
+    {
+        var variant = GetSelectedVariant();
+        var hit = variant == null ? null : GetFirstHit(variant);
+        return hit?.FindPropertyRelative("AttackEffect");
+    }
+
+    private void CreateEffectPreview(SerializedProperty effect)
+    {
+        DestroyEffectPreview();
+        var prefab = effect.FindPropertyRelative("_previewPrefab").objectReferenceValue as GameObject;
+        if (prefab == null) return;
+
+        _effectPreviewInstance = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
+        if (_effectPreviewInstance == null)
+            _effectPreviewInstance = Instantiate(prefab);
+
+        _effectPreviewInstance.hideFlags = HideFlags.HideAndDontSave;
+        SceneView.RepaintAll();
+    }
+
+    private void DestroyEffectPreview()
+    {
+        if (_effectPreviewInstance == null) return;
+        DestroyImmediate(_effectPreviewInstance);
+        _effectPreviewInstance = null;
+    }
+
+    private void DrawEffectTransformHandle(Vector3 pivot, Vector3 dir)
+    {
+        var effect = GetSelectedEffect();
+        if (effect == null || _effectPreviewInstance == null) return;
+
+        var localPosition = effect.FindPropertyRelative("_localPosition");
+        var localEuler = effect.FindPropertyRelative("_localEulerAngles");
+        var localScale = effect.FindPropertyRelative("_localScale");
+        Quaternion referenceRotation = Quaternion.LookRotation(dir, Vector3.up);
+        Vector3 worldPosition = pivot + referenceRotation * localPosition.vector3Value;
+        Quaternion worldRotation = referenceRotation * Quaternion.Euler(localEuler.vector3Value);
+        Vector3 fittedScale = CalculatePreviewScale(GetFirstHit(GetSelectedVariant()), effect);
+
+        _effectPreviewInstance.transform.SetPositionAndRotation(worldPosition, worldRotation);
+        _effectPreviewInstance.transform.localScale = fittedScale;
+
+        EditorGUI.BeginChangeCheck();
+        switch (_effectTransformTool)
+        {
+            case EffectTransformTool.Move:
+                worldPosition = Handles.PositionHandle(worldPosition, worldRotation);
+                break;
+            case EffectTransformTool.Rotate:
+                worldRotation = Handles.RotationHandle(worldRotation, worldPosition);
+                break;
+            case EffectTransformTool.Scale:
+                localScale.vector3Value = Handles.ScaleHandle(
+                    localScale.vector3Value,
+                    worldPosition,
+                    worldRotation,
+                    HandleUtility.GetHandleSize(worldPosition));
+                break;
+        }
+
+        if (!EditorGUI.EndChangeCheck()) return;
+
+        Undo.RecordObjects(targets, "Edit Attack Effect Transform");
+        if (_effectTransformTool == EffectTransformTool.Move)
+            localPosition.vector3Value = Quaternion.Inverse(referenceRotation) * (worldPosition - pivot);
+        else if (_effectTransformTool == EffectTransformTool.Rotate)
+            localEuler.vector3Value = (Quaternion.Inverse(referenceRotation) * worldRotation).eulerAngles;
+
+        serializedObject.ApplyModifiedProperties();
+        SceneView.RepaintAll();
+    }
+
+    private static Vector3 CalculatePreviewScale(SerializedProperty hit, SerializedProperty effect)
+    {
+        Vector3 scale = effect.FindPropertyRelative("_localScale").vector3Value;
+        if (!effect.FindPropertyRelative("_fitToAttackArea").boolValue) return scale;
+
+        float range = hit.FindPropertyRelative("AttackRange").floatValue;
+        float radius = hit.FindPropertyRelative("AttackRadius").floatValue;
+        Vector3 baseSize = effect.FindPropertyRelative("_baseSize").vector3Value;
+        Vector3 fit = new(
+            (range + radius) / Mathf.Max(0.01f, baseSize.x),
+            (radius * 2f) / Mathf.Max(0.01f, baseSize.y),
+            (radius * 2f) / Mathf.Max(0.01f, baseSize.z));
+        return Vector3.Scale(fit, scale);
     }
 
     private static SerializedProperty GetFirstHit(SerializedProperty variant)
@@ -491,6 +598,13 @@ public class AttackDataEditor : Editor
         texture.SetPixels(pixels);
         texture.Apply();
         return texture;
+    }
+
+    private enum EffectTransformTool
+    {
+        Move,
+        Rotate,
+        Scale,
     }
 }
 #endif

--- a/Assets/Editor/AttackDataEditor.cs
+++ b/Assets/Editor/AttackDataEditor.cs
@@ -476,17 +476,7 @@ public class AttackDataEditor : Editor
 
     private static Vector3 CalculatePreviewScale(SerializedProperty hit, SerializedProperty effect)
     {
-        Vector3 scale = effect.FindPropertyRelative("_localScale").vector3Value;
-        if (!effect.FindPropertyRelative("_fitToAttackArea").boolValue) return scale;
-
-        float range = hit.FindPropertyRelative("AttackRange").floatValue;
-        float radius = hit.FindPropertyRelative("AttackRadius").floatValue;
-        Vector3 baseSize = effect.FindPropertyRelative("_baseSize").vector3Value;
-        Vector3 fit = new(
-            (range + radius) / Mathf.Max(0.01f, baseSize.x),
-            (radius * 2f) / Mathf.Max(0.01f, baseSize.y),
-            (radius * 2f) / Mathf.Max(0.01f, baseSize.z));
-        return Vector3.Scale(fit, scale);
+        return effect.FindPropertyRelative("_localScale").vector3Value;
     }
 
     private static SerializedProperty GetFirstHit(SerializedProperty variant)

--- a/Assets/Editor/AttackDataEditor.cs
+++ b/Assets/Editor/AttackDataEditor.cs
@@ -476,7 +476,17 @@ public class AttackDataEditor : Editor
 
     private static Vector3 CalculatePreviewScale(SerializedProperty hit, SerializedProperty effect)
     {
-        return effect.FindPropertyRelative("_localScale").vector3Value;
+        Vector3 scale = effect.FindPropertyRelative("_localScale").vector3Value;
+        if (!effect.FindPropertyRelative("_fitToAttackArea").boolValue) return scale;
+
+        float range = hit.FindPropertyRelative("AttackRange").floatValue;
+        float radius = hit.FindPropertyRelative("AttackRadius").floatValue;
+        Vector3 baseSize = effect.FindPropertyRelative("_baseSize").vector3Value;
+        Vector3 fit = new(
+            (range + radius) / Mathf.Max(0.01f, baseSize.x),
+            (radius * 2f) / Mathf.Max(0.01f, baseSize.y),
+            (radius * 2f) / Mathf.Max(0.01f, baseSize.z));
+        return Vector3.Scale(fit, scale);
     }
 
     private static SerializedProperty GetFirstHit(SerializedProperty variant)

--- a/Assets/Editor/AttackEffectLayoutWindow.cs
+++ b/Assets/Editor/AttackEffectLayoutWindow.cs
@@ -1,0 +1,369 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+public class AttackEffectLayoutWindow : EditorWindow
+{
+    [MenuItem("Tools/Attack/Effect Layout Editor")]
+    private static void OpenFromMenu() => Open(null);
+
+    public static void Open(AttackData data, int variantIndex = 0)
+    {
+        var window = GetWindow<AttackEffectLayoutWindow>("Attack Effect Layout");
+        window.minSize = new Vector2(390f, 430f);
+        window.SetData(data, variantIndex);
+        window.Show();
+    }
+
+    private AttackData _data;
+    private SerializedObject _serializedData;
+    private GameObject _referenceObject;
+    private GameObject _previewInstance;
+    private int _variantIndex;
+    private int _hitIndex;
+    private TransformTool _tool;
+    private Vector2 _scroll;
+    private bool _isPreviewPlaying;
+    private double _lastEditorTime;
+
+    private void OnEnable()
+    {
+        SceneView.duringSceneGui += OnSceneGUI;
+        EditorApplication.update += UpdatePreviewPlayback;
+        _lastEditorTime = EditorApplication.timeSinceStartup;
+    }
+
+    private void OnDisable()
+    {
+        SceneView.duringSceneGui -= OnSceneGUI;
+        EditorApplication.update -= UpdatePreviewPlayback;
+        DestroyPreview();
+    }
+
+    private void SetData(AttackData data, int variantIndex)
+    {
+        _data = data;
+        _serializedData = data != null ? new SerializedObject(data) : null;
+        _variantIndex = variantIndex;
+        _hitIndex = 0;
+        Repaint();
+    }
+
+    private void OnGUI()
+    {
+        EditorGUI.BeginChangeCheck();
+        var selected = (AttackData)EditorGUILayout.ObjectField("Attack Data", _data, typeof(AttackData), false);
+        if (EditorGUI.EndChangeCheck())
+            SetData(selected, 0);
+
+        if (_data == null || _serializedData == null)
+        {
+            EditorGUILayout.HelpBox("編集するAttackDataを選択してください。", MessageType.Info);
+            return;
+        }
+
+        _serializedData.Update();
+        var variants = _serializedData.FindProperty("_variants");
+        if (variants == null || variants.arraySize == 0)
+        {
+            EditorGUILayout.HelpBox("Variantがありません。", MessageType.Warning);
+            return;
+        }
+
+        _variantIndex = Mathf.Clamp(_variantIndex, 0, variants.arraySize - 1);
+        _variantIndex = EditorGUILayout.Popup("Charge / Variant", _variantIndex, BuildVariantNames(variants));
+        var variant = variants.GetArrayElementAtIndex(_variantIndex);
+        var hits = variant.FindPropertyRelative("_hits");
+        if (hits == null || hits.arraySize == 0)
+        {
+            EditorGUILayout.HelpBox("Hitデータがありません。", MessageType.Warning);
+            return;
+        }
+
+        _hitIndex = Mathf.Clamp(_hitIndex, 0, hits.arraySize - 1);
+        if (hits.arraySize > 1)
+            _hitIndex = EditorGUILayout.IntSlider("Hit", _hitIndex, 0, hits.arraySize - 1);
+
+        var hit = hits.GetArrayElementAtIndex(_hitIndex);
+        var effect = hit.FindPropertyRelative("AttackEffect");
+        if (effect == null)
+        {
+            EditorGUILayout.HelpBox("AttackEffect設定がありません。", MessageType.Error);
+            return;
+        }
+
+        EditorGUILayout.Space(5);
+        EditorGUILayout.LabelField("Preview Objects", EditorStyles.boldLabel);
+        _referenceObject = (GameObject)EditorGUILayout.ObjectField(
+            "Reference Object", _referenceObject, typeof(GameObject), true);
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_previewPrefab"), new GUIContent("Target VFX"));
+
+        EditorGUILayout.BeginHorizontal();
+        if (_previewInstance == null)
+        {
+            if (GUILayout.Button("Show Preview", GUILayout.Height(24))) CreatePreview(effect);
+        }
+        else
+        {
+            if (GUILayout.Button("Refresh Preview", GUILayout.Height(24))) CreatePreview(effect);
+            if (GUILayout.Button("Hide Preview", GUILayout.Height(24))) DestroyPreview();
+        }
+        EditorGUILayout.EndHorizontal();
+
+        using (new EditorGUI.DisabledScope(_previewInstance == null))
+        {
+            EditorGUILayout.Space(3);
+            EditorGUILayout.LabelField("Playback", EditorStyles.miniBoldLabel);
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button("▶ Play", GUILayout.Height(25))) PlayPreview();
+            if (GUILayout.Button("Ⅱ Pause", GUILayout.Height(25))) PausePreview();
+            if (GUILayout.Button("↻ Restart", GUILayout.Height(25))) RestartPreview();
+            if (GUILayout.Button("■ Stop", GUILayout.Height(25))) StopPreview();
+            EditorGUILayout.EndHorizontal();
+        }
+
+        EditorGUILayout.Space(7);
+        EditorGUILayout.LabelField("Transform", EditorStyles.boldLabel);
+        _tool = (TransformTool)GUILayout.Toolbar((int)_tool, new[] { "Move", "Rotate", "Scale" });
+
+        _scroll = EditorGUILayout.BeginScrollView(_scroll);
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_localPosition"), new GUIContent("Local Position"));
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_localEulerAngles"), new GUIContent("Local Rotation"));
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_localScale"), new GUIContent("Additional Scale"));
+
+        EditorGUILayout.Space(7);
+        EditorGUILayout.LabelField("Automatic Size", EditorStyles.boldLabel);
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_fitToAttackArea"), new GUIContent("Fit To Attack Area"));
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_baseSize"), new GUIContent("VFX Base Size"));
+
+        float range = hit.FindPropertyRelative("AttackRange").floatValue;
+        float radius = hit.FindPropertyRelative("AttackRadius").floatValue;
+        Vector3 finalScale = CalculateScale(hit, effect);
+        EditorGUILayout.HelpBox(
+            $"Attack Range: {range:F2}  Radius: {radius:F2}\nFinal Scale: {finalScale.x:F3}, {finalScale.y:F3}, {finalScale.z:F3}",
+            MessageType.None);
+
+        EditorGUILayout.Space(7);
+        EditorGUILayout.LabelField("Runtime", EditorStyles.boldLabel);
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_enabled"));
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_effectKey"));
+        EditorGUILayout.EndScrollView();
+
+        if (_serializedData.ApplyModifiedProperties())
+        {
+            EditorUtility.SetDirty(_data);
+            SceneView.RepaintAll();
+        }
+    }
+
+    private void OnSceneGUI(SceneView sceneView)
+    {
+        if (_serializedData == null || _previewInstance == null) return;
+        if (!TryGetHitAndEffect(out var hit, out var effect)) return;
+
+        GetReferenceTransform(sceneView, out Vector3 pivot, out Quaternion referenceRotation);
+        Vector3 localPosition = effect.FindPropertyRelative("_localPosition").vector3Value;
+        Vector3 localEuler = effect.FindPropertyRelative("_localEulerAngles").vector3Value;
+        Vector3 worldPosition = pivot + referenceRotation * localPosition;
+        Quaternion worldRotation = referenceRotation * Quaternion.Euler(localEuler);
+
+        _previewInstance.transform.SetPositionAndRotation(worldPosition, worldRotation);
+        _previewInstance.transform.localScale = CalculateScale(hit, effect);
+        DrawAttackArea(pivot, referenceRotation * Vector3.forward, hit);
+
+        EditorGUI.BeginChangeCheck();
+        switch (_tool)
+        {
+            case TransformTool.Move:
+                worldPosition = Handles.PositionHandle(worldPosition, worldRotation);
+                break;
+            case TransformTool.Rotate:
+                worldRotation = Handles.RotationHandle(worldRotation, worldPosition);
+                break;
+            case TransformTool.Scale:
+                var scaleProperty = effect.FindPropertyRelative("_localScale");
+                scaleProperty.vector3Value = Handles.ScaleHandle(
+                    scaleProperty.vector3Value, worldPosition, worldRotation,
+                    HandleUtility.GetHandleSize(worldPosition));
+                break;
+        }
+
+        if (!EditorGUI.EndChangeCheck()) return;
+        Undo.RecordObject(_data, "Edit Attack Effect Layout");
+        if (_tool == TransformTool.Move)
+            effect.FindPropertyRelative("_localPosition").vector3Value =
+                Quaternion.Inverse(referenceRotation) * (worldPosition - pivot);
+        else if (_tool == TransformTool.Rotate)
+            effect.FindPropertyRelative("_localEulerAngles").vector3Value =
+                (Quaternion.Inverse(referenceRotation) * worldRotation).eulerAngles;
+
+        _serializedData.ApplyModifiedProperties();
+        EditorUtility.SetDirty(_data);
+        Repaint();
+    }
+
+    private bool TryGetHitAndEffect(out SerializedProperty hit, out SerializedProperty effect)
+    {
+        _serializedData.Update();
+        var variants = _serializedData.FindProperty("_variants");
+        if (variants == null || variants.arraySize == 0)
+        {
+            hit = effect = null;
+            return false;
+        }
+        _variantIndex = Mathf.Clamp(_variantIndex, 0, variants.arraySize - 1);
+        var hits = variants.GetArrayElementAtIndex(_variantIndex).FindPropertyRelative("_hits");
+        if (hits == null || hits.arraySize == 0)
+        {
+            hit = effect = null;
+            return false;
+        }
+        _hitIndex = Mathf.Clamp(_hitIndex, 0, hits.arraySize - 1);
+        hit = hits.GetArrayElementAtIndex(_hitIndex);
+        effect = hit.FindPropertyRelative("AttackEffect");
+        return effect != null;
+    }
+
+    private void GetReferenceTransform(SceneView sceneView, out Vector3 pivot, out Quaternion rotation)
+    {
+        if (_referenceObject != null)
+        {
+            pivot = _referenceObject.transform.position;
+            rotation = _referenceObject.transform.rotation;
+            return;
+        }
+        pivot = sceneView.camera.transform.position + sceneView.camera.transform.forward * 5f;
+        pivot.y = 0f;
+        rotation = Quaternion.identity;
+    }
+
+    private void CreatePreview(SerializedProperty effect)
+    {
+        DestroyPreview();
+        var prefab = effect.FindPropertyRelative("_previewPrefab").objectReferenceValue as GameObject;
+        if (prefab == null) return;
+        _previewInstance = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
+        if (_previewInstance == null) _previewInstance = Instantiate(prefab);
+        _previewInstance.hideFlags = HideFlags.HideAndDontSave;
+        RestartPreview();
+        SceneView.RepaintAll();
+    }
+
+    private void DestroyPreview()
+    {
+        if (_previewInstance == null) return;
+        DestroyImmediate(_previewInstance);
+        _previewInstance = null;
+        _isPreviewPlaying = false;
+        SceneView.RepaintAll();
+    }
+
+    private void PlayPreview()
+    {
+        if (_previewInstance == null) return;
+        foreach (var particle in GetRootParticles())
+            particle.Play(true);
+        _isPreviewPlaying = true;
+        _lastEditorTime = EditorApplication.timeSinceStartup;
+    }
+
+    private void PausePreview()
+    {
+        if (_previewInstance == null) return;
+        foreach (var particle in GetRootParticles())
+            particle.Pause(true);
+        _isPreviewPlaying = false;
+        SceneView.RepaintAll();
+    }
+
+    private void RestartPreview()
+    {
+        if (_previewInstance == null) return;
+        foreach (var particle in GetRootParticles())
+        {
+            particle.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+            particle.Simulate(0f, true, true, true);
+            particle.Play(true);
+        }
+        _isPreviewPlaying = true;
+        _lastEditorTime = EditorApplication.timeSinceStartup;
+        SceneView.RepaintAll();
+    }
+
+    private void StopPreview()
+    {
+        if (_previewInstance == null) return;
+        foreach (var particle in GetRootParticles())
+            particle.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+        _isPreviewPlaying = false;
+        SceneView.RepaintAll();
+    }
+
+    private ParticleSystem[] GetRootParticles()
+    {
+        var particles = _previewInstance.GetComponentsInChildren<ParticleSystem>(true);
+        var roots = new System.Collections.Generic.List<ParticleSystem>();
+        foreach (var particle in particles)
+        {
+            Transform parent = particle.transform.parent;
+            if (parent == null || parent.GetComponentInParent<ParticleSystem>() == null)
+                roots.Add(particle);
+        }
+        return roots.ToArray();
+    }
+
+    private void UpdatePreviewPlayback()
+    {
+        double now = EditorApplication.timeSinceStartup;
+        float deltaTime = Mathf.Min((float)(now - _lastEditorTime), 0.05f);
+        _lastEditorTime = now;
+        if (!_isPreviewPlaying || _previewInstance == null || deltaTime <= 0f) return;
+
+        foreach (var particle in GetRootParticles())
+            particle.Simulate(deltaTime, true, false, true);
+
+        SceneView.RepaintAll();
+        Repaint();
+    }
+
+    private static Vector3 CalculateScale(SerializedProperty hit, SerializedProperty effect)
+    {
+        Vector3 scale = effect.FindPropertyRelative("_localScale").vector3Value;
+        if (!effect.FindPropertyRelative("_fitToAttackArea").boolValue) return scale;
+        float range = hit.FindPropertyRelative("AttackRange").floatValue;
+        float radius = hit.FindPropertyRelative("AttackRadius").floatValue;
+        Vector3 size = effect.FindPropertyRelative("_baseSize").vector3Value;
+        return Vector3.Scale(new Vector3(
+            (range + radius) / Mathf.Max(0.01f, size.x),
+            (radius * 2f) / Mathf.Max(0.01f, size.y),
+            (radius * 2f) / Mathf.Max(0.01f, size.z)), scale);
+    }
+
+    private static void DrawAttackArea(Vector3 pivot, Vector3 forward, SerializedProperty hit)
+    {
+        float range = hit.FindPropertyRelative("AttackRange").floatValue;
+        float radius = hit.FindPropertyRelative("AttackRadius").floatValue;
+        Vector3 center = pivot + forward * range;
+        Handles.color = new Color(1f, 0.25f, 0.2f, 0.85f);
+        Handles.DrawWireDisc(center, Vector3.up, radius);
+        Handles.DrawWireDisc(center, Vector3.right, radius);
+        Handles.DrawWireDisc(center, Vector3.forward, radius);
+        Handles.DrawDottedLine(pivot, center, 4f);
+    }
+
+    private static string[] BuildVariantNames(SerializedProperty variants)
+    {
+        var names = new string[variants.arraySize];
+        for (int i = 0; i < variants.arraySize; i++)
+        {
+            var variant = variants.GetArrayElementAtIndex(i);
+            string name = variant.FindPropertyRelative("_attackName").stringValue;
+            var charge = (ChargeLevel)variant.FindPropertyRelative("_requiredCharge").intValue;
+            names[i] = $"[{i}] {name} ({charge})";
+        }
+        return names;
+    }
+
+    private enum TransformTool { Move, Rotate, Scale }
+}
+#endif

--- a/Assets/Editor/AttackEffectLayoutWindow.cs
+++ b/Assets/Editor/AttackEffectLayoutWindow.cs
@@ -129,18 +129,13 @@ public class AttackEffectLayoutWindow : EditorWindow
         _scroll = EditorGUILayout.BeginScrollView(_scroll);
         EditorGUILayout.PropertyField(effect.FindPropertyRelative("_localPosition"), new GUIContent("Local Position"));
         EditorGUILayout.PropertyField(effect.FindPropertyRelative("_localEulerAngles"), new GUIContent("Local Rotation"));
-        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_localScale"), new GUIContent("Additional Scale"));
-
-        EditorGUILayout.Space(7);
-        EditorGUILayout.LabelField("Automatic Size", EditorStyles.boldLabel);
-        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_fitToAttackArea"), new GUIContent("Fit To Attack Area"));
-        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_baseSize"), new GUIContent("VFX Base Size"));
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_localScale"), new GUIContent("Local Scale"));
 
         float range = hit.FindPropertyRelative("AttackRange").floatValue;
         float radius = hit.FindPropertyRelative("AttackRadius").floatValue;
         Vector3 finalScale = CalculateScale(hit, effect);
         EditorGUILayout.HelpBox(
-            $"Attack Range: {range:F2}  Radius: {radius:F2}\nFinal Scale: {finalScale.x:F3}, {finalScale.y:F3}, {finalScale.z:F3}",
+            $"Attack Range: {range:F2}  Radius: {radius:F2}\nEffect Scale: {finalScale.x:F3}, {finalScale.y:F3}, {finalScale.z:F3}\n赤い攻撃判定を目安に手動でサイズを調整してください。",
             MessageType.None);
 
         EditorGUILayout.Space(7);
@@ -328,15 +323,7 @@ public class AttackEffectLayoutWindow : EditorWindow
 
     private static Vector3 CalculateScale(SerializedProperty hit, SerializedProperty effect)
     {
-        Vector3 scale = effect.FindPropertyRelative("_localScale").vector3Value;
-        if (!effect.FindPropertyRelative("_fitToAttackArea").boolValue) return scale;
-        float range = hit.FindPropertyRelative("AttackRange").floatValue;
-        float radius = hit.FindPropertyRelative("AttackRadius").floatValue;
-        Vector3 size = effect.FindPropertyRelative("_baseSize").vector3Value;
-        return Vector3.Scale(new Vector3(
-            (range + radius) / Mathf.Max(0.01f, size.x),
-            (radius * 2f) / Mathf.Max(0.01f, size.y),
-            (radius * 2f) / Mathf.Max(0.01f, size.z)), scale);
+        return effect.FindPropertyRelative("_localScale").vector3Value;
     }
 
     private static void DrawAttackArea(Vector3 pivot, Vector3 forward, SerializedProperty hit)

--- a/Assets/Editor/AttackEffectLayoutWindow.cs
+++ b/Assets/Editor/AttackEffectLayoutWindow.cs
@@ -129,13 +129,18 @@ public class AttackEffectLayoutWindow : EditorWindow
         _scroll = EditorGUILayout.BeginScrollView(_scroll);
         EditorGUILayout.PropertyField(effect.FindPropertyRelative("_localPosition"), new GUIContent("Local Position"));
         EditorGUILayout.PropertyField(effect.FindPropertyRelative("_localEulerAngles"), new GUIContent("Local Rotation"));
-        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_localScale"), new GUIContent("Local Scale"));
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_localScale"), new GUIContent("Additional Scale"));
+
+        EditorGUILayout.Space(7);
+        EditorGUILayout.LabelField("Automatic Size", EditorStyles.boldLabel);
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_fitToAttackArea"), new GUIContent("Fit To Attack Area"));
+        EditorGUILayout.PropertyField(effect.FindPropertyRelative("_baseSize"), new GUIContent("VFX Base Size"));
 
         float range = hit.FindPropertyRelative("AttackRange").floatValue;
         float radius = hit.FindPropertyRelative("AttackRadius").floatValue;
         Vector3 finalScale = CalculateScale(hit, effect);
         EditorGUILayout.HelpBox(
-            $"Attack Range: {range:F2}  Radius: {radius:F2}\nEffect Scale: {finalScale.x:F3}, {finalScale.y:F3}, {finalScale.z:F3}\n赤い攻撃判定を目安に手動でサイズを調整してください。",
+            $"Attack Range: {range:F2}  Radius: {radius:F2}\nFinal Scale: {finalScale.x:F3}, {finalScale.y:F3}, {finalScale.z:F3}",
             MessageType.None);
 
         EditorGUILayout.Space(7);
@@ -323,7 +328,15 @@ public class AttackEffectLayoutWindow : EditorWindow
 
     private static Vector3 CalculateScale(SerializedProperty hit, SerializedProperty effect)
     {
-        return effect.FindPropertyRelative("_localScale").vector3Value;
+        Vector3 scale = effect.FindPropertyRelative("_localScale").vector3Value;
+        if (!effect.FindPropertyRelative("_fitToAttackArea").boolValue) return scale;
+        float range = hit.FindPropertyRelative("AttackRange").floatValue;
+        float radius = hit.FindPropertyRelative("AttackRadius").floatValue;
+        Vector3 size = effect.FindPropertyRelative("_baseSize").vector3Value;
+        return Vector3.Scale(new Vector3(
+            (range + radius) / Mathf.Max(0.01f, size.x),
+            (radius * 2f) / Mathf.Max(0.01f, size.y),
+            (radius * 2f) / Mathf.Max(0.01f, size.z)), scale);
     }
 
     private static void DrawAttackArea(Vector3 pivot, Vector3 forward, SerializedProperty hit)

--- a/Assets/Editor/AttackEffectLayoutWindow.cs.meta
+++ b/Assets/Editor/AttackEffectLayoutWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 04cdf8cde2da4e0d9f01b6aa21409652

--- a/Assets/Prefab/Effect/Attack/WarriorPiercingEarth.prefab
+++ b/Assets/Prefab/Effect/Attack/WarriorPiercingEarth.prefab
@@ -1,0 +1,5167 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5877295649237120576
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1922726265473180208}
+  - component: {fileID: 2764857859391063342}
+  - component: {fileID: 7933702298211243493}
+  m_Layer: 0
+  m_Name: PS_VFX_Piercing (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1922726265473180208
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5877295649237120576}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.38268343, y: 0, z: 0, w: 0.92387956}
+  m_LocalPosition: {x: -5.42, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1369202335652477267}
+  m_LocalEulerAnglesHint: {x: 45, y: 0, z: 0}
+--- !u!198 &2764857859391063342
+ParticleSystem:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5877295649237120576}
+  serializedVersion: 8
+  lengthInSec: 5
+  simulationSpeed: 1
+  stopAction: 0
+  cullingMode: 0
+  ringBufferMode: 0
+  ringBufferLoopRange: {x: 0, y: 1}
+  emitterVelocityMode: 1
+  looping: 0
+  prewarm: 0
+  playOnAwake: 1
+  useUnscaledTime: 0
+  autoRandomSeed: 1
+  startDelay:
+    serializedVersion: 2
+    minMaxState: 0
+    scalar: 0
+    minScalar: 0
+    maxCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    minCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  moveWithTransform: 0
+  moveWithCustomTransform: {fileID: 0}
+  scalingMode: 0
+  randomSeed: 0
+  InitialModule:
+    serializedVersion: 3
+    enabled: 1
+    startLifetime:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0.75
+      minScalar: 5
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startSpeed:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 5
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startColor:
+      serializedVersion: 2
+      minMaxState: 0
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+    startSize:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0.17
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startSizeY:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0.05
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startSizeZ:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0.05
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startRotationX:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startRotationY:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 3.1415925
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startRotation:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    randomizeRotationDirection: 0
+    gravitySource: 0
+    maxNumParticles: 1000
+    customEmitterVelocity: {x: 0, y: 0, z: 0}
+    size3D: 1
+    rotation3D: 1
+    gravityModifier:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+  ShapeModule:
+    serializedVersion: 6
+    enabled: 0
+    type: 4
+    angle: 25
+    length: 5
+    boxThickness: {x: 0, y: 0, z: 0}
+    radiusThickness: 1
+    donutRadius: 0.2
+    m_Position: {x: 0, y: 0, z: 0}
+    m_Rotation: {x: 0, y: 0, z: 0}
+    m_Scale: {x: 1, y: 1, z: 1}
+    placementMode: 0
+    m_MeshMaterialIndex: 0
+    m_MeshNormalOffset: 0
+    m_MeshSpawn:
+      mode: 0
+      spread: 0
+      speed:
+        serializedVersion: 2
+        minMaxState: 0
+        scalar: 1
+        minScalar: 1
+        maxCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        minCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+    m_Mesh: {fileID: 0}
+    m_MeshRenderer: {fileID: 0}
+    m_SkinnedMeshRenderer: {fileID: 0}
+    m_Sprite: {fileID: 0}
+    m_SpriteRenderer: {fileID: 0}
+    m_UseMeshMaterialIndex: 0
+    m_UseMeshColors: 1
+    alignToDirection: 0
+    m_Texture: {fileID: 0}
+    m_TextureClipChannel: 3
+    m_TextureClipThreshold: 0
+    m_TextureUVChannel: 0
+    m_TextureColorAffectsParticles: 1
+    m_TextureAlphaAffectsParticles: 1
+    m_TextureBilinearFiltering: 0
+    randomDirectionAmount: 0
+    sphericalDirectionAmount: 0
+    randomPositionAmount: 0
+    radius:
+      value: 1
+      mode: 0
+      spread: 0
+      speed:
+        serializedVersion: 2
+        minMaxState: 0
+        scalar: 1
+        minScalar: 1
+        maxCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        minCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+    arc:
+      value: 360
+      mode: 0
+      spread: 0
+      speed:
+        serializedVersion: 2
+        minMaxState: 0
+        scalar: 1
+        minScalar: 1
+        maxCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        minCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+  EmissionModule:
+    enabled: 1
+    serializedVersion: 4
+    rateOverTime:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 10
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    rateOverDistance:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    m_BurstCount: 1
+    m_Bursts:
+    - serializedVersion: 2
+      time: 0
+      countCurve:
+        serializedVersion: 2
+        minMaxState: 0
+        scalar: 1
+        minScalar: 30
+        maxCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        minCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+      cycleCount: 1
+      repeatInterval: 0.01
+      probability: 1
+  SizeModule:
+    enabled: 1
+    curve:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1.4
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0.7116974
+          inSlope: 0.29997393
+          outSlope: 0.29997393
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.1097852
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0.2999999
+          outSlope: 0.2999999
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.11933172
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    z:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    separateAxes: 0
+  RotationModule:
+    enabled: 0
+    x:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    curve:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 24.434608
+      minScalar: 0.7853982
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: -1
+          inSlope: 6.875001
+          outSlope: 6.875001
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.12728718
+        - serializedVersion: 3
+          time: 0.2
+          value: -0.2
+          inSlope: 0.6135459
+          outSlope: 0.6135459
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.1497613
+        - serializedVersion: 3
+          time: 1
+          value: -0.04749564
+          inSlope: -0.05799997
+          outSlope: -0.05799997
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.17047396
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    separateAxes: 0
+  ColorModule:
+    enabled: 1
+    gradient:
+      serializedVersion: 2
+      minMaxState: 1
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 0}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 22402
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+  UVModule:
+    serializedVersion: 2
+    enabled: 0
+    mode: 0
+    timeMode: 0
+    fps: 30
+    frameOverTime:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 0.9999
+      minScalar: 0.9999
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startFrame:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    speedRange: {x: 0, y: 1}
+    tilesX: 1
+    tilesY: 1
+    animationType: 0
+    rowIndex: 0
+    cycles: 1
+    uvChannelMask: -1
+    rowMode: 1
+    sprites:
+    - sprite: {fileID: 0}
+    flipU: 0
+    flipV: 0
+  VelocityModule:
+    enabled: 1
+    x:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 20
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: -2.6666677
+          outSlope: -2.6666677
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.03579952
+        - serializedVersion: 3
+          time: 0.2958099
+          value: 0.19295128
+          inSlope: -0.6362236
+          outSlope: -0.6362236
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.16964814
+        - serializedVersion: 3
+          time: 1
+          value: 0.019088745
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    z:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    orbitalX:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    orbitalY:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    orbitalZ:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    orbitalOffsetX:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    orbitalOffsetY:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    orbitalOffsetZ:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    radial:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    speedModifier:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 3.5
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    inWorldSpace: 0
+  InheritVelocityModule:
+    enabled: 0
+    m_Mode: 0
+    m_Curve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+  LifetimeByEmitterSpeedModule:
+    enabled: 0
+    m_Curve:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: -0.8
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0.2
+          inSlope: -0.8
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    m_Range: {x: 0, y: 1}
+  ForceModule:
+    enabled: 0
+    x:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    z:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    inWorldSpace: 0
+    randomizePerFrame: 0
+  ExternalForcesModule:
+    serializedVersion: 2
+    enabled: 0
+    multiplierCurve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    influenceFilter: 0
+    influenceMask:
+      serializedVersion: 2
+      m_Bits: 4294967295
+    influenceList: []
+  ClampVelocityModule:
+    enabled: 0
+    x:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    z:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    magnitude:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    separateAxis: 0
+    inWorldSpace: 0
+    multiplyDragByParticleSize: 1
+    multiplyDragByParticleVelocity: 1
+    dampen: 0
+    drag:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+  NoiseModule:
+    enabled: 0
+    strength:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    strengthY:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    strengthZ:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    separateAxes: 0
+    frequency: 0.5
+    damping: 1
+    octaves: 1
+    octaveMultiplier: 0.5
+    octaveScale: 2
+    quality: 2
+    scrollSpeed:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    remap:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: -1
+          inSlope: 0
+          outSlope: 2
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 2
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    remapY:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: -1
+          inSlope: 0
+          outSlope: 2
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 2
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    remapZ:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: -1
+          inSlope: 0
+          outSlope: 2
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 2
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    remapEnabled: 0
+    positionAmount:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    rotationAmount:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    sizeAmount:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+  SizeBySpeedModule:
+    enabled: 0
+    curve:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    z:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    range: {x: 0, y: 1}
+    separateAxes: 0
+  RotationBySpeedModule:
+    enabled: 0
+    x:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    curve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0.7853982
+      minScalar: 0.7853982
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    separateAxes: 0
+    range: {x: 0, y: 1}
+  ColorBySpeedModule:
+    enabled: 0
+    gradient:
+      serializedVersion: 2
+      minMaxState: 1
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+    range: {x: 0, y: 1}
+  CollisionModule:
+    enabled: 0
+    serializedVersion: 4
+    type: 0
+    collisionMode: 0
+    colliderForce: 0
+    multiplyColliderForceByParticleSize: 0
+    multiplyColliderForceByParticleSpeed: 0
+    multiplyColliderForceByCollisionAngle: 1
+    m_Planes: []
+    m_Dampen:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    m_Bounce:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    m_EnergyLossOnCollision:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    minKillSpeed: 0
+    maxKillSpeed: 10000
+    radiusScale: 1
+    collidesWith:
+      serializedVersion: 2
+      m_Bits: 4294967295
+    maxCollisionShapes: 256
+    quality: 0
+    voxelSize: 0.5
+    collisionMessages: 0
+    collidesWithDynamic: 1
+    interiorCollisions: 0
+  TriggerModule:
+    enabled: 0
+    serializedVersion: 2
+    inside: 1
+    outside: 0
+    enter: 0
+    exit: 0
+    colliderQueryMode: 0
+    radiusScale: 1
+    primitives: []
+  SubModule:
+    serializedVersion: 2
+    enabled: 0
+    subEmitters:
+    - serializedVersion: 3
+      emitter: {fileID: 0}
+      type: 0
+      properties: 0
+      emitProbability: 1
+  LightsModule:
+    enabled: 0
+    ratio: 0
+    light: {fileID: 0}
+    randomDistribution: 1
+    color: 1
+    range: 1
+    intensity: 1
+    rangeCurve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    intensityCurve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    maxLights: 20
+  TrailModule:
+    enabled: 0
+    mode: 0
+    ratio: 1
+    lifetime:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    minVertexDistance: 0.2
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    ribbonCount: 1
+    shadowBias: 0.5
+    worldSpace: 0
+    dieWithParticles: 1
+    sizeAffectsWidth: 1
+    sizeAffectsLifetime: 0
+    inheritParticleColor: 1
+    generateLightingData: 0
+    splitSubEmitterRibbons: 0
+    attachRibbonsToTransform: 0
+    colorOverLifetime:
+      serializedVersion: 2
+      minMaxState: 0
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+    widthOverTrail:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    colorOverTrail:
+      serializedVersion: 2
+      minMaxState: 0
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+  CustomDataModule:
+    enabled: 1
+    mode0: 1
+    vectorComponentCount0: 4
+    color0:
+      serializedVersion: 2
+      minMaxState: 0
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+    colorLabel0: Color
+    vector0_0:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1.5
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: -3.8181818
+          outSlope: -3.8181818
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.52505964
+        - serializedVersion: 3
+          time: 0.10287285
+          value: 0.67182904
+          inSlope: 0.5717149
+          outSlope: 0.5717149
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.1461236
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: -0.04878037
+          outSlope: -0.04878037
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.21744901
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel0_0: X
+    vector0_1:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0.102388
+          value: -0.0056719966
+          inSlope: 0.16250002
+          outSlope: 0.16250002
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.20997374
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 2.8421006
+          outSlope: 2.8421006
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.0506534
+          outWeight: 0
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel0_1: Y
+    vector0_2:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel0_2: Z
+    vector0_3:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel0_3: W
+    mode1: 0
+    vectorComponentCount1: 4
+    color1:
+      serializedVersion: 2
+      minMaxState: 0
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+    colorLabel1: Color
+    vector1_0:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel1_0: X
+    vector1_1:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel1_1: Y
+    vector1_2:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel1_2: Z
+    vector1_3:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel1_3: W
+--- !u!199 &7933702298211243493
+ParticleSystemRenderer:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5877295649237120576}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: df0cf35d5e52d2d4a821833fc7fb1225, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_RenderMode: 4
+  m_MeshDistribution: 0
+  m_SortMode: 0
+  m_MinParticleSize: 0
+  m_MaxParticleSize: 0.5
+  m_CameraVelocityScale: 0
+  m_VelocityScale: 0
+  m_LengthScale: 2
+  m_SortingFudge: 0
+  m_NormalDirection: 1
+  m_ShadowBias: 0
+  m_RenderAlignment: 2
+  m_Pivot: {x: 0, y: 0, z: 0}
+  m_Flip: {x: 0, y: 0, z: 0}
+  m_EnableGPUInstancing: 1
+  m_ApplyActiveColorSpace: 1
+  m_AllowRoll: 1
+  m_FreeformStretching: 0
+  m_RotateWithStretchDirection: 1
+  m_UseCustomVertexStreams: 1
+  m_VertexStreams: 0001030420
+  m_UseCustomTrailVertexStreams: 0
+  m_TrailVertexStreams: 00010304
+  m_Mesh: {fileID: -3894122102765240045, guid: 0083edc2796c9dd419d40afb8772004e, type: 3}
+  m_Mesh1: {fileID: 0}
+  m_Mesh2: {fileID: 0}
+  m_Mesh3: {fileID: 0}
+  m_MeshWeighting: 1
+  m_MeshWeighting1: 1
+  m_MeshWeighting2: 1
+  m_MeshWeighting3: 1
+--- !u!1 &6100000000000000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6100000000000000002}
+  - component: {fileID: 6100000000000000003}
+  m_Layer: 0
+  m_Name: WarriorPiercingEarth
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6100000000000000002
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6100000000000000001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1369202335652477267}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6100000000000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6100000000000000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f83dae22c9ab10418f5ecb7a2520c16, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ParticleEffect
+  _rootParticle: {fileID: 1219264961983858532}
+--- !u!1001 &6100000000000000010
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6100000000000000002}
+    m_Modifications:
+    - target: {fileID: 2512956114697863415, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.atime1
+      value: 65535
+      objectReference: {fileID: 0}
+    - target: {fileID: 2512956114697863415, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.ctime0
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2512956114697863415, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key0.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2512956114697863415, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key0.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2512956114697863415, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key0.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2512956114697863415, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key1.a
+      value: 0.20784314
+      objectReference: {fileID: 0}
+    - target: {fileID: 2512956114697863415, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key1.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2512956114697863415, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key1.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2512956114697863415, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.m_ColorSpace
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2512956114697863415, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.m_NumAlphaKeys
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5163359291806153049, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5163359291806153049, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5163359291806153049, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5163359291806153049, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5163359291806153049, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5163359291806153049, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5163359291806153049, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 5163359291806153049, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 5163359291806153049, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 5163359291806153049, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035049574075399089, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.atime0
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035049574075399089, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.atime1
+      value: 65535
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035049574075399089, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.ctime0
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035049574075399089, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.ctime1
+      value: 65535
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035049574075399089, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key0.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035049574075399089, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key0.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035049574075399089, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key0.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035049574075399089, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key1.a
+      value: 0.20784314
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035049574075399089, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key1.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035049574075399089, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key1.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6035049574075399089, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.m_ColorSpace
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6620966694190176761, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: m_Name
+      value: VFX_Piercing_Earth
+      objectReference: {fileID: 0}
+    - target: {fileID: 7379073600893945521, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: InitialModule.startColor.maxColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7379073600893945521, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: InitialModule.startColor.maxColor.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7379073600893945521, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: InitialModule.startColor.maxColor.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7760548105782138985, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7999971205535351157, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.atime1
+      value: 65535
+      objectReference: {fileID: 0}
+    - target: {fileID: 7999971205535351157, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.ctime0
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7999971205535351157, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key1.a
+      value: 0.20784314
+      objectReference: {fileID: 0}
+    - target: {fileID: 7999971205535351157, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key1.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7999971205535351157, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key1.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7999971205535351157, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.key1.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7999971205535351157, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      propertyPath: ColorModule.gradient.maxGradient.m_NumAlphaKeys
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 5163359291806153049, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+      insertIndex: 1
+      addedObject: {fileID: 1922726265473180208}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+--- !u!198 &1219264961983858532 stripped
+ParticleSystem:
+  m_CorrespondingSourceObject: {fileID: 4921377399851108206, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+  m_PrefabInstance: {fileID: 6100000000000000010}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1369202335652477267 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5163359291806153049, guid: 5553949e1595f7748aaa4583fece2ecd, type: 3}
+  m_PrefabInstance: {fileID: 6100000000000000010}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefab/Effect/Attack/WarriorPiercingEarth.prefab.meta
+++ b/Assets/Prefab/Effect/Attack/WarriorPiercingEarth.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 78da2ac1686b4c58a0bb91038f4e1402
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Prefab/System/Manager.prefab
+++ b/Assets/Prefab/System/Manager.prefab
@@ -117,6 +117,8 @@ MonoBehaviour:
     _prefab: {fileID: 3812723360568179772, guid: b1e7e059141b9b44fa290fda79777263, type: 3}
   - _key: BossArmorHit
     _prefab: {fileID: -5381235673946462251, guid: 7756c357a0ebb1f4c850b1da613c25b9, type: 3}
+  - _key: WarriorPiercingEarth
+    _prefab: {fileID: 6100000000000000003, guid: 78da2ac1686b4c58a0bb91038f4e1402, type: 3}
   _preloadCount: 5
 --- !u!1 &1357235700894819526
 GameObject:
@@ -1395,31 +1397,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.x
-      value: 357.7636
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.y
-      value: 259.04453
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
-      value: 96.60663
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.x
-      value: -0.0699569
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.y
-      value: 0.75289166
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.z
-      value: 0.01448657
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.x
-      value: 1.0000002
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.y
@@ -1427,7 +1429,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2864870325628134270, guid: fd0a0d567ddfb6443acccd654c6f8480, type: 3}
       propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.z
-      value: 1.0000001
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/TestScenes/GOTestScene.unity
+++ b/Assets/Scenes/TestScenes/GOTestScene.unity
@@ -829,6 +829,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineCamera
+--- !u!4 &230102734 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4455957007473277194, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
+  m_PrefabInstance: {fileID: 650177779}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &238664269
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1544,42 +1549,10 @@ PrefabInstance:
       propertyPath: _warriorEffectView
       value: 
       objectReference: {fileID: 1861598003}
-    - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.x
-      value: -0.29603958
-      objectReference: {fileID: 0}
-    - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.y
-      value: 0.14262
-      objectReference: {fileID: 0}
-    - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.z
-      value: 0.12065983
-      objectReference: {fileID: 0}
-    - target: {fileID: 527146034796436033, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.y
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 527146034796436045, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: Target
       value: 
       objectReference: {fileID: 1150124032}
-    - target: {fileID: 3900919356117798245, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 15.9
-      objectReference: {fileID: 0}
     - target: {fileID: 3913965231841061834, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: m_Name
       value: Manager
@@ -1639,11 +1612,7 @@ PrefabInstance:
     - target: {fileID: 7246669613523359550, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: _enemyUIParent
       value: 
-      objectReference: {fileID: 728091136}
-    - target: {fileID: 7374466586915306897, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 8.04
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1158805227}
     - target: {fileID: 7457554239091016240, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: Target
       value: 
@@ -1651,35 +1620,7 @@ PrefabInstance:
     - target: {fileID: 7457554239091016243, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: Target
       value: 
-      objectReference: {fileID: 1150124032}
-    - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[3].m_Value.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.x
-      value: -0.29603958
-      objectReference: {fileID: 0}
-    - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.y
-      value: 0.14262
-      objectReference: {fileID: 0}
-    - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[4].m_Value.z
-      value: 0.12065983
-      objectReference: {fileID: 0}
-    - target: {fileID: 7457554239091016255, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_PropertySheet.m_Vector3f.m_Array.Array.data[5].m_Value.y
-      value: 1
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 230102734}
     - target: {fileID: 7748896386332537814, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: _player
       value: 
@@ -1688,26 +1629,6 @@ PrefabInstance:
       propertyPath: _playerGaugeView
       value: 
       objectReference: {fileID: 728091137}
-    - target: {fileID: 7793837620590366497, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _playerTransform
-      value: 
-      objectReference: {fileID: 650177780}
-    - target: {fileID: 7793837620590366497, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _allSpawnPoints.Array.size
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 7822539410125592448, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_SceneBindings.Array.data[0].value
-      value: 
-      objectReference: {fileID: 511524225}
-    - target: {fileID: 7822539410125592448, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_SceneBindings.Array.data[1].value
-      value: 
-      objectReference: {fileID: 1801617614}
-    - target: {fileID: 7822539410125592448, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: m_SceneBindings.Array.data[2].value
-      value: 
-      objectReference: {fileID: 182414174}
     - target: {fileID: 7908005230863849075, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: _gaugeParent
       value: 
@@ -1720,18 +1641,6 @@ PrefabInstance:
       propertyPath: _armerGaugeParent
       value: 
       objectReference: {fileID: 1291428025}
-    - target: {fileID: 7933280528869699832, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _spawnSlots.Array.size
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 7933280528869699832, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _spawnSlots.Array.data[2].x
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7933280528869699832, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _spawnSlots.Array.data[2].z
-      value: -1
-      objectReference: {fileID: 0}
     - target: {fileID: 8440135078367233537, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: _lockOnCamera
       value: 
@@ -1740,90 +1649,14 @@ PrefabInstance:
       propertyPath: _normalCamera
       value: 
       objectReference: {fileID: 288517074}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.size
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[2]._key
-      value: "\u5927\u5730\u7C89\u7815"
-      objectReference: {fileID: 0}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[3]._key
-      value: "\u30C6\u30B9\u30C8\u8840\u3057\u3076\u304D"
-      objectReference: {fileID: 0}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[4]._key
-      value: "\u30C6\u30B9\u30C8\u706B\u82B1"
-      objectReference: {fileID: 0}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[5]._key
-      value: "\u30C6\u30B9\u30C8\u5CA9"
-      objectReference: {fileID: 0}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[6]._key
-      value: "\u30C6\u30B9\u30C8\u96F7\u30D2\u30C3\u30C8\u30A8\u30D5\u30A7\u30AF\u30C8"
-      objectReference: {fileID: 0}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[7]._key
-      value: "\u30C6\u30B9\u30C8\u30A2\u30FC\u30DE\u30FC\u7834\u58CA"
-      objectReference: {fileID: 0}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[8]._key
-      value: Rock
-      objectReference: {fileID: 0}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[2]._prefab
-      value: 
-      objectReference: {fileID: 567102852122591039, guid: 803bfbd5bb757094ba960334876d8581, type: 3}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[3]._prefab
-      value: 
-      objectReference: {fileID: 7500359468652911350, guid: c6b78d1dc878b124fb4603ee5d0c96d5, type: 3}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[4]._prefab
-      value: 
-      objectReference: {fileID: 4538616225021936692, guid: 5b4f2ffeddb18a743b845bbc64f3fcb1, type: 3}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[5]._prefab
-      value: 
-      objectReference: {fileID: -5381235673946462251, guid: bf0228cca4454014a80b8b303b7e630e, type: 3}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[6]._prefab
-      value: 
-      objectReference: {fileID: 146184047964149964, guid: 618f481dad270584ab4a2b6970264d75, type: 3}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[7]._prefab
-      value: 
-      objectReference: {fileID: 7530617160647338765, guid: c6ca6326235194944ab29c48ab546f26, type: 3}
-    - target: {fileID: 8809870427891784214, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _effectDataList.Array.data[8]._prefab
-      value: 
-      objectReference: {fileID: 8833923644228565619, guid: 2aa072756bb89ba43b4c51482593ab69, type: 3}
-    - target: {fileID: 9128100736884302578, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: _firstSequence
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9128100736884302578, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: managedReferences[6731506274227978448]._mobSequenceName
-      value: "\u30E2\u30D6\u6226\u95D8"
-      objectReference: {fileID: 0}
     - target: {fileID: 9128100736884302578, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: managedReferences[6731506274227978448]._skillSelectView
       value: 
       objectReference: {fileID: 1504407408}
     - target: {fileID: 9128100736884302578, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: managedReferences[6731506274227978450]._bossSequenceName
-      value: "\u30DC\u30B9\u6226\u95D8"
-      objectReference: {fileID: 0}
-    - target: {fileID: 9128100736884302578, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: managedReferences[6731506274227978453]._gameOverTimerView
       value: 
       objectReference: {fileID: 1839641876}
-    - target: {fileID: 9128100736884302578, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
-      propertyPath: managedReferences[6731506274227978448]._mobBattleTimeLimit
-      value: 180
-      objectReference: {fileID: 0}
     - target: {fileID: 9128100736884302578, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
       propertyPath: managedReferences[6731506274227978448]._mobBattleTimerView
       value: 
@@ -1849,8 +1682,7 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1870438423}
     m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 6508732559360190048, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
+    m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dffdac0096150b34bb48d124ac240ea0, type: 3}
@@ -3181,6 +3013,22 @@ PrefabInstance:
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
       objectReference: {fileID: 2100000, guid: a7b113dc87819f44faef9811cfaaf997, type: 2}
+    - target: {fileID: 7971035984183082400, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
+      propertyPath: _warriorAttackEffectBaseWidth
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971035984183082400, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
+      propertyPath: _warriorAttackEffectBaseLength
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971035984183082400, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
+      propertyPath: _warriorAttackEffectScaleMultiplier
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971035984183082400, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
+      propertyPath: _warriorAttackEffectLocalEulerAngles.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8223305388128248287, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.90142006
@@ -12422,7 +12270,7 @@ PrefabInstance:
     - target: {fileID: 492242463749214196, guid: 55041d558fe7af84dae8e2b81f3d6022, type: 3}
       propertyPath: m_fontAsset
       value: 
-      objectReference: {fileID: 11400000, guid: 9675f3f9f3d7a044a8af5dd67f86bba6, type: 2}
+      objectReference: {fileID: 11400000, guid: c53246874463c39428c8189e5d3415d4, type: 2}
     - target: {fileID: 492242463749214196, guid: 55041d558fe7af84dae8e2b81f3d6022, type: 3}
       propertyPath: m_fontSizeBase
       value: 40
@@ -12430,7 +12278,7 @@ PrefabInstance:
     - target: {fileID: 492242463749214196, guid: 55041d558fe7af84dae8e2b81f3d6022, type: 3}
       propertyPath: m_sharedMaterial
       value: 
-      objectReference: {fileID: 5139381610417544147, guid: 9675f3f9f3d7a044a8af5dd67f86bba6, type: 2}
+      objectReference: {fileID: 2649257169248792476, guid: c53246874463c39428c8189e5d3415d4, type: 2}
     - target: {fileID: 492242463749214196, guid: 55041d558fe7af84dae8e2b81f3d6022, type: 3}
       propertyPath: m_hasFontAssetChanged
       value: 0
@@ -13080,7 +12928,7 @@ PrefabInstance:
     - target: {fileID: 2228108133039262262, guid: 5f42b4a09d597a64b91ed36254f8d071, type: 3}
       propertyPath: m_fontAsset
       value: 
-      objectReference: {fileID: 11400000, guid: 9675f3f9f3d7a044a8af5dd67f86bba6, type: 2}
+      objectReference: {fileID: 11400000, guid: c53246874463c39428c8189e5d3415d4, type: 2}
     - target: {fileID: 2228108133039262262, guid: 5f42b4a09d597a64b91ed36254f8d071, type: 3}
       propertyPath: m_fontStyle
       value: 32
@@ -13104,7 +12952,7 @@ PrefabInstance:
     - target: {fileID: 2228108133039262262, guid: 5f42b4a09d597a64b91ed36254f8d071, type: 3}
       propertyPath: m_sharedMaterial
       value: 
-      objectReference: {fileID: 5139381610417544147, guid: 9675f3f9f3d7a044a8af5dd67f86bba6, type: 2}
+      objectReference: {fileID: 2649257169248792476, guid: c53246874463c39428c8189e5d3415d4, type: 2}
     - target: {fileID: 2228108133039262262, guid: 5f42b4a09d597a64b91ed36254f8d071, type: 3}
       propertyPath: m_VerticalAlignment
       value: 256

--- a/Assets/Scripts/Data/Player/AttackVariantData.cs
+++ b/Assets/Scripts/Data/Player/AttackVariantData.cs
@@ -126,17 +126,23 @@ public class AttackEffectData
 {
     public bool Enabled => _enabled;
     public string EffectKey => _effectKey;
+    public bool FitToAttackArea => _fitToAttackArea;
+    public Vector3 BaseSize => _baseSize;
     public Vector3 LocalPosition => _localPosition;
     public Vector3 LocalEulerAngles => _localEulerAngles;
     public Vector3 LocalScale => _localScale;
 
     [SerializeField] private bool _enabled = true;
     [SerializeField] private string _effectKey = "WarriorPiercingEarth";
+    [Tooltip("Fit the effect length and width to AttackRange and AttackRadius.")]
+    [SerializeField] private bool _fitToAttackArea = true;
+    [Tooltip("Original VFX size. X is length; Y and Z are width.")]
+    [SerializeField] private Vector3 _baseSize = new(10f, 2f, 2f);
     [Tooltip("Local position relative to the reference object.")]
     [SerializeField] private Vector3 _localPosition = new(0f, 0.05f, 0f);
     [Tooltip("Local Euler rotation relative to the reference object.")]
     [SerializeField] private Vector3 _localEulerAngles = new(0f, 90f, 0f);
-    [Tooltip("Effect scale.")]
+    [Tooltip("Additional scale applied after automatic fitting.")]
     [SerializeField] private Vector3 _localScale = Vector3.one;
 
 #if UNITY_EDITOR

--- a/Assets/Scripts/Data/Player/AttackVariantData.cs
+++ b/Assets/Scripts/Data/Player/AttackVariantData.cs
@@ -126,23 +126,17 @@ public class AttackEffectData
 {
     public bool Enabled => _enabled;
     public string EffectKey => _effectKey;
-    public bool FitToAttackArea => _fitToAttackArea;
-    public Vector3 BaseSize => _baseSize;
     public Vector3 LocalPosition => _localPosition;
     public Vector3 LocalEulerAngles => _localEulerAngles;
     public Vector3 LocalScale => _localScale;
 
     [SerializeField] private bool _enabled = true;
     [SerializeField] private string _effectKey = "WarriorPiercingEarth";
-    [Tooltip("Fit the effect length and width to AttackRange and AttackRadius.")]
-    [SerializeField] private bool _fitToAttackArea = true;
-    [Tooltip("Original VFX size. X is length; Y and Z are width.")]
-    [SerializeField] private Vector3 _baseSize = new(10f, 2f, 2f);
     [Tooltip("Local position relative to the reference object.")]
     [SerializeField] private Vector3 _localPosition = new(0f, 0.05f, 0f);
     [Tooltip("Local Euler rotation relative to the reference object.")]
     [SerializeField] private Vector3 _localEulerAngles = new(0f, 90f, 0f);
-    [Tooltip("Additional scale applied after automatic fitting.")]
+    [Tooltip("Effect scale.")]
     [SerializeField] private Vector3 _localScale = Vector3.one;
 
 #if UNITY_EDITOR

--- a/Assets/Scripts/Data/Player/AttackVariantData.cs
+++ b/Assets/Scripts/Data/Player/AttackVariantData.cs
@@ -87,6 +87,7 @@ public class AttackHitData
         KnockbackUpward = 0f,
         PlayGroundHitSE = false,
         AdditionalLightningDamages = Array.Empty<AdditionalLightningDamageData>(),
+        AttackEffect = new AttackEffectData(),
     };
 
     public bool HasAdditionalLightningDamage =>
@@ -115,4 +116,37 @@ public class AttackHitData
 
     [Header("カメラシェイク")]
     public CameraShakeData CameraShakeData;
+
+    [Header("Attack Effect")]
+    public AttackEffectData AttackEffect = new();
+}
+
+[Serializable]
+public class AttackEffectData
+{
+    public bool Enabled => _enabled;
+    public string EffectKey => _effectKey;
+    public bool FitToAttackArea => _fitToAttackArea;
+    public Vector3 BaseSize => _baseSize;
+    public Vector3 LocalPosition => _localPosition;
+    public Vector3 LocalEulerAngles => _localEulerAngles;
+    public Vector3 LocalScale => _localScale;
+
+    [SerializeField] private bool _enabled = true;
+    [SerializeField] private string _effectKey = "WarriorPiercingEarth";
+    [Tooltip("Fit the effect length and width to AttackRange and AttackRadius.")]
+    [SerializeField] private bool _fitToAttackArea = true;
+    [Tooltip("Original VFX size. X is length; Y and Z are width.")]
+    [SerializeField] private Vector3 _baseSize = new(10f, 2f, 2f);
+    [Tooltip("Local position relative to the reference object.")]
+    [SerializeField] private Vector3 _localPosition = new(0f, 0.05f, 0f);
+    [Tooltip("Local Euler rotation relative to the reference object.")]
+    [SerializeField] private Vector3 _localEulerAngles = new(0f, 90f, 0f);
+    [Tooltip("Additional scale applied after automatic fitting.")]
+    [SerializeField] private Vector3 _localScale = Vector3.one;
+
+#if UNITY_EDITOR
+    [Tooltip("Target prefab displayed by AttackDataEditor. Runtime playback uses Effect Key.")]
+    [SerializeField] private GameObject _previewPrefab;
+#endif
 }

--- a/Assets/Scripts/Effect/EffectManager.cs
+++ b/Assets/Scripts/Effect/EffectManager.cs
@@ -12,12 +12,21 @@ public class EffectManager : MonoBehaviour
 {
     public void PlayEffect(string key, Vector3 position)
     {
-        PlayEffect(key, position, Vector3.one);
+        PlayEffect(key, position, Quaternion.identity, Vector3.one);
     }
 
     public void PlayEffect(
         string key,
         Vector3 position,
+        Vector3 scale)
+    {
+        PlayEffect(key, position, Quaternion.identity, scale);
+    }
+
+    public void PlayEffect(
+        string key,
+        Vector3 position,
+        Quaternion rotation,
         Vector3 scale)
     {
         if (!_pools.TryGetValue(key, out var pool))
@@ -34,7 +43,7 @@ public class EffectManager : MonoBehaviour
 
         presenter.PlayAsync(
             position,
-            Quaternion.identity,
+            rotation,
             _cts.Token).Forget();
     }
 

--- a/Assets/Scripts/Player/AttackExecutor.cs
+++ b/Assets/Scripts/Player/AttackExecutor.cs
@@ -44,6 +44,9 @@ public class AttackExecutor : MonoBehaviour
         var attackPos = transform.position + transform.forward * hitData.AttackRange;
         var cols = Physics.OverlapSphere(attackPos, hitData.AttackRadius, _layer);
 
+        if (attackData.Mode == PlayerMode.Warrior && attackInput.ChargeLevel > ChargeLevel.None)
+            PlayWarriorAttackEffect(hitData);
+
         Debug.Log($"{attackData.Mode}：{variantData.AttackName}で攻撃");
 
         var context = new AttackContext(attackData.Mode, _playerStats, attackPos, transform)
@@ -147,6 +150,36 @@ public class AttackExecutor : MonoBehaviour
     [SerializeField] private Color _lightningDamagePopupColor = DamagePopupColorScope.LightningColor;
     private IPlayerStats _playerStats;
     private SkillManager _skillManager;
+
+    private void PlayWarriorAttackEffect(AttackHitData hitData)
+    {
+        AttackEffectData effect = hitData.AttackEffect;
+        if (effect == null || !effect.Enabled || string.IsNullOrEmpty(effect.EffectKey)) return;
+        if (!ServiceLocator.TryGet(out EffectManager effectManager)) return;
+
+        Vector3 scale = effect.LocalScale;
+        if (effect.FitToAttackArea)
+        {
+            float length = Mathf.Max(0.01f, hitData.AttackRange + hitData.AttackRadius);
+            float width = Mathf.Max(0.01f, hitData.AttackRadius * 2f);
+            Vector3 baseSize = effect.BaseSize;
+            Vector3 fitScale = new(
+                length / Mathf.Max(0.01f, baseSize.x),
+                width / Mathf.Max(0.01f, baseSize.y),
+                width / Mathf.Max(0.01f, baseSize.z));
+            scale = Vector3.Scale(fitScale, scale);
+        }
+
+        Vector3 position = transform.TransformPoint(effect.LocalPosition);
+        Quaternion rotation = Quaternion.LookRotation(transform.forward, Vector3.up)
+                              * Quaternion.Euler(effect.LocalEulerAngles);
+
+        effectManager.PlayEffect(
+            effect.EffectKey,
+            position,
+            rotation,
+            scale);
+    }
 
     private List<SkillBase> GetApplicableSkills(AttackContext context, AttackData data)
     {

--- a/Assets/Scripts/Player/AttackExecutor.cs
+++ b/Assets/Scripts/Player/AttackExecutor.cs
@@ -158,6 +158,17 @@ public class AttackExecutor : MonoBehaviour
         if (!ServiceLocator.TryGet(out EffectManager effectManager)) return;
 
         Vector3 scale = effect.LocalScale;
+        if (effect.FitToAttackArea)
+        {
+            float length = Mathf.Max(0.01f, hitData.AttackRange + hitData.AttackRadius);
+            float width = Mathf.Max(0.01f, hitData.AttackRadius * 2f);
+            Vector3 baseSize = effect.BaseSize;
+            Vector3 fitScale = new(
+                length / Mathf.Max(0.01f, baseSize.x),
+                width / Mathf.Max(0.01f, baseSize.y),
+                width / Mathf.Max(0.01f, baseSize.z));
+            scale = Vector3.Scale(fitScale, scale);
+        }
 
         Vector3 position = transform.TransformPoint(effect.LocalPosition);
         Quaternion rotation = Quaternion.LookRotation(transform.forward, Vector3.up)

--- a/Assets/Scripts/Player/AttackExecutor.cs
+++ b/Assets/Scripts/Player/AttackExecutor.cs
@@ -158,17 +158,6 @@ public class AttackExecutor : MonoBehaviour
         if (!ServiceLocator.TryGet(out EffectManager effectManager)) return;
 
         Vector3 scale = effect.LocalScale;
-        if (effect.FitToAttackArea)
-        {
-            float length = Mathf.Max(0.01f, hitData.AttackRange + hitData.AttackRadius);
-            float width = Mathf.Max(0.01f, hitData.AttackRadius * 2f);
-            Vector3 baseSize = effect.BaseSize;
-            Vector3 fitScale = new(
-                length / Mathf.Max(0.01f, baseSize.x),
-                width / Mathf.Max(0.01f, baseSize.y),
-                width / Mathf.Max(0.01f, baseSize.z));
-            scale = Vector3.Scale(fitScale, scale);
-        }
 
         Vector3 position = transform.TransformPoint(effect.LocalPosition);
         Quaternion rotation = Quaternion.LookRotation(transform.forward, Vector3.up)

--- a/Assets/Visual test.meta
+++ b/Assets/Visual test.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: f51cf5166e12ac840a9c762786b4f013
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 攻撃ヒットに「攻撃効果（有効/キー/位置・回転・スケール）」を追加し、条件に応じてエフェクトを再生します。
  * エディタに「攻撃効果レイアウト」ウィンドウを追加。VFXプレビューの表示/再生制御と、シーン上の移動・回転・拡大縮小編集に対応します。
* **改善**
  * エフェクト再生が回転指定に対応し、配置の反映がより正確になります。
  * 範囲に合わせてスケール調整（FitToAttackArea）できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->