### PR TITLE
ダメージリアクション差分の追加

### DIFF
--- a/Assets/Animation/Player.controller
+++ b/Assets/Animation/Player.controller
@@ -45,6 +45,120 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &700000000000000011
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name:
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Damaged
+    m_EventTreshold: 0
+  - m_ConditionMode: 6
+    m_ConditionEvent: DamageReaction
+    m_EventTreshold: 1
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 700000000000000001}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &700000000000000012
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name:
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Damaged
+    m_EventTreshold: 0
+  - m_ConditionMode: 6
+    m_ConditionEvent: DamageReaction
+    m_EventTreshold: 2
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 700000000000000002}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &700000000000000001
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DamageMedium
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 2905920023066227485}
+  - {fileID: -7754152362994246711}
+  m_StateMachineBehaviours:
+  - {fileID: 2376104391524022071}
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 1827226128182048838, guid: dea0632ae86271647ad9dfd18771d53e, type: 3}
+  m_Tag:
+  m_SpeedParameter:
+  m_MirrorParameter:
+  m_CycleOffsetParameter:
+  m_TimeParameter:
+--- !u!1102 &700000000000000002
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DamageLarge
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 2905920023066227485}
+  - {fileID: -7754152362994246711}
+  m_StateMachineBehaviours:
+  - {fileID: 2376104391524022071}
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 1827226128182048838, guid: dea0632ae86271647ad9dfd18771d53e, type: 3}
+  m_Tag:
+  m_SpeedParameter:
+  m_MirrorParameter:
+  m_CycleOffsetParameter:
+  m_TimeParameter:
 --- !u!114 &-9121446091816207823
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -307,6 +421,12 @@ AnimatorStateMachine:
     m_State: {fileID: 8685627706576656378}
     m_Position: {x: 870, y: -120, z: 0}
   - serializedVersion: 1
+    m_State: {fileID: 700000000000000001}
+    m_Position: {x: 1070, y: -120, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 700000000000000002}
+    m_Position: {x: 1270, y: -120, z: 0}
+  - serializedVersion: 1
     m_State: {fileID: -9003048759167319259}
     m_Position: {x: 510, y: -400, z: 0}
   m_ChildStateMachines:
@@ -325,6 +445,8 @@ AnimatorStateMachine:
   m_AnyStateTransitions:
   - {fileID: -3633140483132136186}
   - {fileID: -3821991315590443592}
+  - {fileID: 700000000000000011}
+  - {fileID: 700000000000000012}
   - {fileID: -3870213955321064331}
   - {fileID: 1188721636029302602}
   m_EntryTransitions: []
@@ -978,6 +1100,9 @@ AnimatorStateTransition:
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: Damaged
+    m_EventTreshold: 0
+  - m_ConditionMode: 6
+    m_ConditionEvent: DamageReaction
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 8685627706576656378}
@@ -1766,6 +1891,12 @@ AnimatorController:
     m_Controller: {fileID: 9100000}
   - m_Name: Damaged
     m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: DamageReaction
+    m_Type: 3
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
@@ -3112,7 +3243,7 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Damaged
+  m_Name: DamageSmall
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:

--- a/Assets/Scripts/Interface/IHealth.cs
+++ b/Assets/Scripts/Interface/IHealth.cs
@@ -1,9 +1,21 @@
 using System;
 using UnityEngine;
 
+/// <summary>
+/// プレイヤーがダメージを受けた際のリアクション強度。
+/// 指定しない既存の攻撃は Small として扱う。
+/// </summary>
+public enum DamageReactionType
+{
+    Small = 0,
+    Medium = 1,
+    Large = 2
+}
+
 public interface IHealth
 {
     public event Action<float, float, float> OnHealthChanged;
     public void Healing(float amount);
     public void TakeDamage(float damage);
+    public void TakeDamage(float damage, DamageReactionType reactionType);
 }

--- a/Assets/Scripts/Interface/IPlayerInformationService.cs
+++ b/Assets/Scripts/Interface/IPlayerInformationService.cs
@@ -25,4 +25,8 @@ public interface IPlayerInformationService
     /// <summary> Playerに対してDamageを与える処理 </summary>
     /// <param name="damage"> Damage量 </param>
     public void TakeDamage(float damage);
+    public void TakeDamage(float damage, DamageReactionType reactionType)
+    {
+        Player.TakeDamage(damage, reactionType);
+    }
 }

--- a/Assets/Scripts/Player/Animation/PlayerAnimationController.cs
+++ b/Assets/Scripts/Player/Animation/PlayerAnimationController.cs
@@ -40,6 +40,11 @@ public class PlayerAnimationController : MonoBehaviour, IAnimationController, IM
     /// <summary>被弾アニメーション終了をSMBから受け取る</summary>
     public void AnimEvent_DamagedEnd() => OnDamagedEnd?.Invoke();
 
+    public void SetDamageReaction(DamageReactionType reactionType)
+    {
+        _animator.SetInteger(AnimParams.DamageReaction, (int)reactionType);
+    }
+
     public void AnimEvent_DodgeInvincibilityStart() => OnDodgeInvincibilityStart?.Invoke();
     public void AnimEvent_DodgeEnd() => OnDodgeEnd?.Invoke();
 
@@ -250,6 +255,7 @@ public class PlayerAnimationController : MonoBehaviour, IAnimationController, IM
         // Int
         public static readonly int AttackId = Animator.StringToHash("AttackId");
         public static readonly int PlayerMode = Animator.StringToHash("PlayerMode");
+        public static readonly int DamageReaction = Animator.StringToHash("DamageReaction");
 
         // Bool
         public static readonly int IsCharging = Animator.StringToHash("IsCharging");

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -169,6 +169,32 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
     }
 
     /// <summary>
+    /// ダメージ計算・無敵・ジャスト回避を通さず、リアクションだけを確認する。
+    /// エディターまたはDevelopment BuildのテストUIから使用する。
+    /// </summary>
+    public bool DebugPlayDamageReaction(DamageReactionType reactionType)
+    {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+        if (_playerStateManager == null
+            || _playerAnimationController == null
+            || _move == null
+            || _playerStateManager.IsDead()
+            || _playerStateManager.IsDamaged())
+        {
+            return false;
+        }
+
+        _attack?.InterruptByDamage();
+        _playerAnimationController.SetDamageReaction(reactionType);
+        _move.PlayDamageReaction(reactionType);
+        _playerStateManager.ChangeState(PlayerState.Damaged);
+        return true;
+#else
+        return false;
+#endif
+    }
+
+    /// <summary>
     /// ステータスに修正を加える。バフ・デバフの適用などに使用。
     /// </summary>
     public void AddModifier(IStatModifier modifier)

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -106,6 +106,11 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
     /// </summary>
     public void TakeDamage(float damage)
     {
+        TakeDamage(damage, DamageReactionType.Small);
+    }
+
+    public void TakeDamage(float damage, DamageReactionType reactionType)
+    {
         if (_playerStateManager.IsDead()) return;
 
         if (CurrentMode == PlayerMode.Thunder
@@ -157,6 +162,8 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
         if (canInterrupt && !_playerStateManager.IsDead())
         {
             _attack?.InterruptByDamage(); // 攻撃内部状態を全てクリア
+            _playerAnimationController.SetDamageReaction(reactionType);
+            _move?.PlayDamageReaction(reactionType);
             _playerStateManager.ChangeState(PlayerState.Damaged);
         }
     }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -169,32 +169,6 @@ public class Player : MonoBehaviour, IPlayer, ISpeedChange
     }
 
     /// <summary>
-    /// ダメージ計算・無敵・ジャスト回避を通さず、リアクションだけを確認する。
-    /// エディターまたはDevelopment BuildのテストUIから使用する。
-    /// </summary>
-    public bool DebugPlayDamageReaction(DamageReactionType reactionType)
-    {
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
-        if (_playerStateManager == null
-            || _playerAnimationController == null
-            || _move == null
-            || _playerStateManager.IsDead()
-            || _playerStateManager.IsDamaged())
-        {
-            return false;
-        }
-
-        _attack?.InterruptByDamage();
-        _playerAnimationController.SetDamageReaction(reactionType);
-        _move.PlayDamageReaction(reactionType);
-        _playerStateManager.ChangeState(PlayerState.Damaged);
-        return true;
-#else
-        return false;
-#endif
-    }
-
-    /// <summary>
     /// ステータスに修正を加える。バフ・デバフの適用などに使用。
     /// </summary>
     public void AddModifier(IStatModifier modifier)

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -60,19 +60,42 @@ public class PlayerMovement : MonoBehaviour
             _modifiers.Add(modifier);
     }
 
+    /// <summary>
+    /// リアクション強度に応じた被弾移動を開始する。
+    /// </summary>
+    public void PlayDamageReaction(DamageReactionType reactionType)
+    {
+        _damageReactionMoveCts?.Cancel();
+        _damageReactionMoveCts?.Dispose();
+        _damageReactionMoveCts = new CancellationTokenSource();
+
+        if (reactionType == DamageReactionType.Small) return;
+
+        bool isMedium = reactionType == DamageReactionType.Medium;
+        PerformDamageReactionMove(
+            reactionType,
+            isMedium ? _mediumReactionDistance : _largeReactionDistance,
+            isMedium ? _mediumReactionDuration : _largeReactionDuration,
+            isMedium ? _mediumReactionMoveCurve : _largeReactionMoveCurve,
+            _damageReactionMoveCts.Token).Forget();
+    }
+
     [SerializeField] private Rigidbody _rb;
 
     [Header("Damage Reaction")]
     [SerializeField, Min(0f)] private float _mediumReactionDistance = 1.5f;
     [SerializeField, Min(0.01f)] private float _mediumReactionDuration = 0.35f;
-    [SerializeField] private AnimationCurve _mediumReactionMoveCurve =
+    [SerializeField]
+    private AnimationCurve _mediumReactionMoveCurve =
         AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
     [SerializeField, Min(0f)] private float _largeReactionDistance = 1.2f;
     [SerializeField, Min(0f)] private float _largeReactionHeight = 1.5f;
     [SerializeField, Min(0.01f)] private float _largeReactionDuration = 0.6f;
-    [SerializeField] private AnimationCurve _largeReactionMoveCurve =
+    [SerializeField]
+    private AnimationCurve _largeReactionMoveCurve =
         AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
-    [SerializeField] private AnimationCurve _largeReactionHeightCurve =
+    [SerializeField]
+    private AnimationCurve _largeReactionHeightCurve =
         new AnimationCurve(
             new Keyframe(0f, 0f, 0f, 4f),
             new Keyframe(0.5f, 1f, 0f, 0f),
@@ -399,23 +422,12 @@ public class PlayerMovement : MonoBehaviour
     // ── 被弾 ─────────────────────────────────────────────────
 
     /// <summary>
-    /// 被弾アニメーション終了イベントのハンドラー。PlayerStateManagerがDamaged状態ならIdleに遷移させる。
+    /// 被弾アニメーション終了時にDamaged状態を解除する。
     /// </summary>
-    public void PlayDamageReaction(DamageReactionType reactionType)
+    private void HandleDamagedEnd()
     {
-        _damageReactionMoveCts?.Cancel();
-        _damageReactionMoveCts?.Dispose();
-        _damageReactionMoveCts = new CancellationTokenSource();
-
-        if (reactionType == DamageReactionType.Small) return;
-
-        bool isMedium = reactionType == DamageReactionType.Medium;
-        PerformDamageReactionMove(
-            reactionType,
-            isMedium ? _mediumReactionDistance : _largeReactionDistance,
-            isMedium ? _mediumReactionDuration : _largeReactionDuration,
-            isMedium ? _mediumReactionMoveCurve : _largeReactionMoveCurve,
-            _damageReactionMoveCts.Token).Forget();
+        if (_playerStateManager.IsDamaged())
+            _playerStateManager.ChangeState(PlayerState.Idle);
     }
 
     private async UniTaskVoid PerformDamageReactionMove(
@@ -502,12 +514,6 @@ public class PlayerMovement : MonoBehaviour
             + horizontalDelta.normalized * Mathf.Min(safeDistance, distance);
         resolved.y = candidatePosition.y;
         return resolved;
-    }
-
-    private void HandleDamagedEnd()
-    {
-        if (_playerStateManager.IsDamaged())
-            _playerStateManager.ChangeState(PlayerState.Idle);
     }
 
     // ── 攻撃移動 ─────────────────────────────────────────────

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -9,6 +9,7 @@ public class PlayerMovement : MonoBehaviour
     private const float INPUT_THRESHOLD = 0.001f;
     private const float ATTACK_MOVE_CAST_SKIN = 0.02f;
     private const float ATTACK_MOVE_MIN_CAST_DISTANCE = 0.001f;
+    private const float DAMAGE_MOVE_CAST_SKIN = 0.02f;
 
     public event Action OnStartDodgeInvincible;
     public event Action OnEndDodge;
@@ -61,6 +62,22 @@ public class PlayerMovement : MonoBehaviour
 
     [SerializeField] private Rigidbody _rb;
 
+    [Header("Damage Reaction")]
+    [SerializeField, Min(0f)] private float _mediumReactionDistance = 1.5f;
+    [SerializeField, Min(0.01f)] private float _mediumReactionDuration = 0.35f;
+    [SerializeField] private AnimationCurve _mediumReactionMoveCurve =
+        AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+    [SerializeField, Min(0f)] private float _largeReactionDistance = 1.2f;
+    [SerializeField, Min(0f)] private float _largeReactionHeight = 1.5f;
+    [SerializeField, Min(0.01f)] private float _largeReactionDuration = 0.6f;
+    [SerializeField] private AnimationCurve _largeReactionMoveCurve =
+        AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+    [SerializeField] private AnimationCurve _largeReactionHeightCurve =
+        new AnimationCurve(
+            new Keyframe(0f, 0f, 0f, 4f),
+            new Keyframe(0.5f, 1f, 0f, 0f),
+            new Keyframe(1f, 0f, -4f, 0f));
+
     private PlayerStateManager _playerStateManager;
     private InputHandler _input;
     private CameraManager _cameraManager;
@@ -76,6 +93,7 @@ public class PlayerMovement : MonoBehaviour
     private bool _isDodging;
     private CancellationTokenSource _dodgeMoveCts;
     private CancellationTokenSource _attackMoveCts;
+    private CancellationTokenSource _damageReactionMoveCts;
     private bool _isAttackMoving;
     private bool _currentIsPhantom;
     private float _attackMoveElapsed;
@@ -142,6 +160,8 @@ public class PlayerMovement : MonoBehaviour
         _dodgeMoveCts?.Dispose();
         _attackMoveCts?.Cancel();
         _attackMoveCts?.Dispose();
+        _damageReactionMoveCts?.Cancel();
+        _damageReactionMoveCts?.Dispose();
     }
 
     // ── 移動 ─────────────────────────────────────────────────
@@ -381,6 +401,89 @@ public class PlayerMovement : MonoBehaviour
     /// <summary>
     /// 被弾アニメーション終了イベントのハンドラー。PlayerStateManagerがDamaged状態ならIdleに遷移させる。
     /// </summary>
+    public void PlayDamageReaction(DamageReactionType reactionType)
+    {
+        _damageReactionMoveCts?.Cancel();
+        _damageReactionMoveCts?.Dispose();
+        _damageReactionMoveCts = new CancellationTokenSource();
+
+        if (reactionType == DamageReactionType.Small) return;
+
+        bool isMedium = reactionType == DamageReactionType.Medium;
+        PerformDamageReactionMove(
+            reactionType,
+            isMedium ? _mediumReactionDistance : _largeReactionDistance,
+            isMedium ? _mediumReactionDuration : _largeReactionDuration,
+            isMedium ? _mediumReactionMoveCurve : _largeReactionMoveCurve,
+            _damageReactionMoveCts.Token).Forget();
+    }
+
+    private async UniTaskVoid PerformDamageReactionMove(
+        DamageReactionType reactionType,
+        float distance,
+        float duration,
+        AnimationCurve moveCurve,
+        CancellationToken cancellationToken)
+    {
+        Vector3 startPosition = _rb.position;
+        Vector3 backward = -transform.forward;
+        backward.y = 0f;
+        backward.Normalize();
+
+        float elapsed = 0f;
+        try
+        {
+            while (elapsed < duration)
+            {
+                elapsed += Time.fixedDeltaTime * _timeScale;
+                float normalizedTime = Mathf.Clamp01(elapsed / duration);
+                float horizontalDistance = moveCurve.Evaluate(normalizedTime) * distance;
+                Vector3 candidate = startPosition + backward * horizontalDistance;
+
+                candidate = ResolveDamageReactionWall(_rb.position, candidate);
+                candidate.y = reactionType == DamageReactionType.Large
+                    ? startPosition.y
+                      + _largeReactionHeightCurve.Evaluate(normalizedTime) * _largeReactionHeight
+                    : startPosition.y;
+
+                _rb.MovePosition(candidate);
+                await UniTask.Yield(PlayerLoopTiming.FixedUpdate, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // 新しいリアクションまたは破棄による中断。
+        }
+    }
+
+    private Vector3 ResolveDamageReactionWall(Vector3 currentPosition, Vector3 candidatePosition)
+    {
+        Vector3 horizontalDelta = candidatePosition - currentPosition;
+        horizontalDelta.y = 0f;
+        float distance = horizontalDelta.magnitude;
+        if (distance <= ATTACK_MOVE_MIN_CAST_DISTANCE) return candidatePosition;
+
+        RaycastHit[] hits = _rb.SweepTestAll(
+            horizontalDelta / distance,
+            distance + DAMAGE_MOVE_CAST_SKIN,
+            QueryTriggerInteraction.Ignore);
+
+        float nearestDistance = float.MaxValue;
+        foreach (RaycastHit hit in hits)
+        {
+            if (!hit.collider || hit.normal.y > 0.5f) continue;
+            nearestDistance = Mathf.Min(nearestDistance, hit.distance);
+        }
+
+        if (nearestDistance == float.MaxValue) return candidatePosition;
+
+        float safeDistance = Mathf.Max(0f, nearestDistance - DAMAGE_MOVE_CAST_SKIN);
+        Vector3 resolved = currentPosition
+            + horizontalDelta.normalized * Mathf.Min(safeDistance, distance);
+        resolved.y = candidatePosition.y;
+        return resolved;
+    }
+
     private void HandleDamagedEnd()
     {
         if (_playerStateManager.IsDamaged())

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -429,6 +429,15 @@ public class PlayerMovement : MonoBehaviour
         Vector3 backward = -transform.forward;
         backward.y = 0f;
         backward.Normalize();
+        bool isLarge = reactionType == DamageReactionType.Large;
+        RigidbodyConstraints originalConstraints = _rb.constraints;
+
+        if (isLarge)
+        {
+            // 通常移動ではY位置を固定しているため、打ち上げ中だけ解除する。
+            // 上下位置そのものは物理速度ではなくAnimationCurveで決定する。
+            _rb.constraints = originalConstraints & ~RigidbodyConstraints.FreezePositionY;
+        }
 
         float elapsed = 0f;
         try
@@ -441,7 +450,7 @@ public class PlayerMovement : MonoBehaviour
                 Vector3 candidate = startPosition + backward * horizontalDistance;
 
                 candidate = ResolveDamageReactionWall(_rb.position, candidate);
-                candidate.y = reactionType == DamageReactionType.Large
+                candidate.y = isLarge
                     ? startPosition.y
                       + _largeReactionHeightCurve.Evaluate(normalizedTime) * _largeReactionHeight
                     : startPosition.y;
@@ -453,6 +462,17 @@ public class PlayerMovement : MonoBehaviour
         catch (OperationCanceledException)
         {
             // 新しいリアクションまたは破棄による中断。
+        }
+        finally
+        {
+            if (isLarge && _rb)
+            {
+                // 中断された場合も地面の高さへ戻し、元の移動制約を復元する。
+                Vector3 landedPosition = _rb.position;
+                landedPosition.y = startPosition.y;
+                _rb.position = landedPosition;
+                _rb.constraints = originalConstraints;
+            }
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 被弾時のリアクションを小・中・大の3段階で指定できるようになりました。
  * ダメージ量に応じて、異なる被弾アニメーションが再生されます。
  * 中・大の被弾リアクションでは、移動距離や継続時間、高さを伴うノックバックを表現します。
  * ノックバック中は壁や障害物との衝突を考慮し、安全に移動します。

* **改善**
  * 従来のダメージ処理は、小リアクションとして引き続き利用できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->