### PR TITLE
ダメージリアクションのアニメーションをアタッチ

### DIFF
--- a/Assets/Animation/Player.controller
+++ b/Assets/Animation/Player.controller
@@ -45,120 +45,6 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &700000000000000011
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name:
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: Damaged
-    m_EventTreshold: 0
-  - m_ConditionMode: 6
-    m_ConditionEvent: DamageReaction
-    m_EventTreshold: 1
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 700000000000000001}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1101 &700000000000000012
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name:
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: Damaged
-    m_EventTreshold: 0
-  - m_ConditionMode: 6
-    m_ConditionEvent: DamageReaction
-    m_EventTreshold: 2
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 700000000000000002}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1102 &700000000000000001
-AnimatorState:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: DamageMedium
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: 2905920023066227485}
-  - {fileID: -7754152362994246711}
-  m_StateMachineBehaviours:
-  - {fileID: 2376104391524022071}
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 1827226128182048838, guid: dea0632ae86271647ad9dfd18771d53e, type: 3}
-  m_Tag:
-  m_SpeedParameter:
-  m_MirrorParameter:
-  m_CycleOffsetParameter:
-  m_TimeParameter:
---- !u!1102 &700000000000000002
-AnimatorState:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: DamageLarge
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: 2905920023066227485}
-  - {fileID: -7754152362994246711}
-  m_StateMachineBehaviours:
-  - {fileID: 2376104391524022071}
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 1827226128182048838, guid: dea0632ae86271647ad9dfd18771d53e, type: 3}
-  m_Tag:
-  m_SpeedParameter:
-  m_MirrorParameter:
-  m_CycleOffsetParameter:
-  m_TimeParameter:
 --- !u!114 &-9121446091816207823
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -382,6 +268,35 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1102 &-7684947183195677380
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: KnockDown_Front_StandUp
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 1138933661006090254}
+  - {fileID: 2531327075966517277}
+  m_StateMachineBehaviours:
+  - {fileID: 6991602902668427626}
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 1827226128182048838, guid: c04c9e9e63c14ca45a4922c34149fcda, type: 3}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1109 &-7655244531643425732
 AnimatorTransition:
   m_ObjectHideFlags: 1
@@ -419,16 +334,19 @@ AnimatorStateMachine:
     m_Position: {x: 220, y: -140, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 8685627706576656378}
-    m_Position: {x: 870, y: -120, z: 0}
+    m_Position: {x: 1100, y: -300, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 700000000000000001}
-    m_Position: {x: 1070, y: -120, z: 0}
+    m_Position: {x: 1220, y: -210, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 700000000000000002}
-    m_Position: {x: 1270, y: -120, z: 0}
+    m_Position: {x: 1420, y: -140, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -9003048759167319259}
     m_Position: {x: 510, y: -400, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -7684947183195677380}
+    m_Position: {x: 1410, y: -80, z: 0}
   m_ChildStateMachines:
   - serializedVersion: 1
     m_StateMachine: {fileID: -7921176991915141101}
@@ -459,13 +377,13 @@ AnimatorStateMachine:
     second:
     - {fileID: -3047913078075690707}
     - {fileID: -335234204994344896}
+  - first: {fileID: 9204221165620375396}
+    second: []
   - first: {fileID: -4045149063401784126}
     second:
     - {fileID: 9085984730038658181}
     - {fileID: -3606997929684375312}
     - {fileID: 5828826817623511597}
-  - first: {fileID: 9204221165620375396}
-    second: []
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: 510, y: -290, z: 0}
   m_EntryPosition: {x: 140, y: 310, z: 0}
@@ -1467,6 +1385,18 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!114 &-2591785614683269979
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c38a1a6531f779b4abf68dd3e27ee0b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::DamagedSMB
 --- !u!1101 &-2558238028153640484
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1994,6 +1924,28 @@ AnimatorTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 1
+--- !u!1101 &518985093212490428
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -7684947183195677380}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &560373011336659301
 AnimatorState:
   serializedVersion: 6
@@ -2023,6 +1975,118 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1102 &700000000000000001
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DamageMedium
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 2905920023066227485}
+  - {fileID: -7754152362994246711}
+  m_StateMachineBehaviours:
+  - {fileID: 6846547599053619446}
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 1827226128182048838, guid: a2d083577a5ebe24f9d207230b56645e, type: 3}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &700000000000000002
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DamageLarge
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 518985093212490428}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 1827226128182048838, guid: 61b7ccfe42771be4c925fba8aea8fc1e, type: 3}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &700000000000000011
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Damaged
+    m_EventTreshold: 0
+  - m_ConditionMode: 6
+    m_ConditionEvent: DamageReaction
+    m_EventTreshold: 1
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 700000000000000001}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &700000000000000012
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Damaged
+    m_EventTreshold: 0
+  - m_ConditionMode: 6
+    m_ConditionEvent: DamageReaction
+    m_EventTreshold: 2
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 700000000000000002}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &713876816379987664
 AnimatorState:
   serializedVersion: 6
@@ -2094,6 +2158,28 @@ MonoBehaviour:
   _comboWindowStartTime: 0.23
   _comboWindowEndTime: 0.45
   _attackCompleteTime: 0.45
+--- !u!1101 &1138933661006090254
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: -1271865628934737004}
+  m_DstState: {fileID: 0}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.85
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &1188721636029302602
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -2309,18 +2395,6 @@ BlendTree:
   m_UseAutomaticThresholds: 0
   m_NormalizedBlendValues: 0
   m_BlendType: 0
---- !u!114 &2376104391524022071
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c38a1a6531f779b4abf68dd3e27ee0b9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::DamagedSMB
 --- !u!114 &2430889264303549175
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2338,6 +2412,28 @@ MonoBehaviour:
   _comboWindowStartTime: 0.96
   _comboWindowEndTime: 1.1
   _attackCompleteTime: 1.1
+--- !u!1101 &2531327075966517277
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: -4045149063401784126}
+  m_DstState: {fileID: 0}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.85
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &2905920023066227485
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -2704,6 +2800,18 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!114 &6846547599053619446
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c38a1a6531f779b4abf68dd3e27ee0b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::DamagedSMB
 --- !u!1102 &6963725926424835810
 AnimatorState:
   serializedVersion: 6
@@ -2731,6 +2839,18 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!114 &6991602902668427626
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c38a1a6531f779b4abf68dd3e27ee0b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::DamagedSMB
 --- !u!1102 &7089469325374448544
 AnimatorState:
   serializedVersion: 6
@@ -3250,7 +3370,7 @@ AnimatorState:
   - {fileID: 2905920023066227485}
   - {fileID: -7754152362994246711}
   m_StateMachineBehaviours:
-  - {fileID: 2376104391524022071}
+  - {fileID: -2591785614683269979}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1

--- a/Assets/Animation/Player.controller
+++ b/Assets/Animation/Player.controller
@@ -2165,7 +2165,10 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions: []
+  m_Conditions:
+  - m_ConditionMode: 6
+    m_ConditionEvent: PlayerMode
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: -1271865628934737004}
   m_DstState: {fileID: 0}
   m_Solo: 0
@@ -2419,7 +2422,10 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions: []
+  m_Conditions:
+  - m_ConditionMode: 6
+    m_ConditionEvent: PlayerMode
+    m_EventTreshold: 1
   m_DstStateMachine: {fileID: -4045149063401784126}
   m_DstState: {fileID: 0}
   m_Solo: 0

--- a/Assets/Scenes/TestScenes/PlayerDamageReactionTestScene.unity
+++ b/Assets/Scenes/TestScenes/PlayerDamageReactionTestScene.unity
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_AmbientSkyColor: {r: 0.45, g: 0.5, b: 0.6, a: 1}
+  m_AmbientEquatorColor: {r: 0.25, g: 0.25, b: 0.25, a: 1}
+  m_AmbientGroundColor: {r: 0.1, g: 0.1, b: 0.1, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.48, b: 0.63, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  m_Layer: 0
+  m_Name: PlayerDamageReactionTestSceneController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1574888b94ec452f8dca9016ec75eab8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PlayerDamageReactionTestSceneController
+  _playerPrefab: {fileID: 7149429084609121715, guid: ba5622985db033b4a902f3bb3f63548c, type: 3}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1001}

--- a/Assets/Scenes/TestScenes/PlayerDamageReactionTestScene.unity.meta
+++ b/Assets/Scenes/TestScenes/PlayerDamageReactionTestScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 30e9f5769d5b4780acc9b84c64110cb4
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Debug.meta
+++ b/Assets/Scripts/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b278116f245b4f53a437244cf361a050
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Debug/PlayerDamageReactionTestSceneController.cs
+++ b/Assets/Scripts/Debug/PlayerDamageReactionTestSceneController.cs
@@ -1,0 +1,137 @@
+using System.Collections;
+using UnityEngine;
+
+/// <summary>
+/// プレイヤーのダメージリアクションだけを確認するテストシーン用Controller。
+/// 敵・GameManager・SequenceManagerは使用しない。
+/// </summary>
+public sealed class PlayerDamageReactionTestSceneController : MonoBehaviour
+{
+    [SerializeField] private Player _playerPrefab;
+
+    private Player _player;
+    private Transform _cameraTransform;
+    private float _nextReactionTime;
+    private string _status = "Initializing...";
+    private GUIStyle _panelStyle;
+    private GUIStyle _buttonStyle;
+    private GUIStyle _labelStyle;
+
+    private IEnumerator Start()
+    {
+        CreateEnvironment();
+
+        InputHandler input;
+        while (!ServiceLocator.TryGet(out input))
+            yield return null;
+
+        if (_playerPrefab == null)
+        {
+            _status = "Player prefab is missing.";
+            yield break;
+        }
+
+        _player = Instantiate(_playerPrefab, Vector3.zero, Quaternion.identity);
+        _player.name = "DamageReactionTestPlayer";
+
+        SkillManager skillManager = new GameObject("TestSkillManager")
+            .AddComponent<SkillManager>();
+        _player.Init(skillManager, input);
+
+        _status = "Ready";
+    }
+
+    private void LateUpdate()
+    {
+        if (_player == null || _cameraTransform == null) return;
+
+        Vector3 target = _player.transform.position + Vector3.up;
+        _cameraTransform.position = target + new Vector3(0f, 3.5f, -7f);
+        _cameraTransform.LookAt(target);
+    }
+
+    private void OnGUI()
+    {
+        EnsureStyles();
+
+        GUILayout.BeginArea(
+            new Rect(20f, 20f, 300f, 285f),
+            "Damage Reaction Test",
+            _panelStyle);
+
+        GUILayout.Space(8f);
+        GUILayout.Label(_status, _labelStyle);
+        GUILayout.Space(10f);
+
+        bool canReact = _player != null && Time.unscaledTime >= _nextReactionTime;
+        GUI.enabled = canReact;
+        DrawReactionButton("Small / 小", DamageReactionType.Small);
+        DrawReactionButton("Medium / 中", DamageReactionType.Medium);
+        DrawReactionButton("Large / 大", DamageReactionType.Large);
+        GUI.enabled = true;
+
+        GUILayout.Space(8f);
+        GUILayout.Label(
+            "WASD: Move\nButtons call TakeDamage with zero damage.",
+            _labelStyle);
+        GUILayout.EndArea();
+    }
+
+    private void DrawReactionButton(string label, DamageReactionType reactionType)
+    {
+        if (!GUILayout.Button(label, _buttonStyle, GUILayout.Height(46f))) return;
+
+        _player.TakeDamage(0f, reactionType);
+        _nextReactionTime = Time.unscaledTime + 1.5f;
+        _status = $"{reactionType} playing";
+    }
+
+    private void CreateEnvironment()
+    {
+        GameObject cameraObject = new GameObject("Main Camera");
+        cameraObject.tag = "MainCamera";
+        cameraObject.AddComponent<Camera>();
+        cameraObject.AddComponent<AudioListener>();
+        _cameraTransform = cameraObject.transform;
+
+        new GameObject("TestCameraManager").AddComponent<CameraManager>();
+
+        CreateCube("Floor", new Vector3(0f, -0.5f, 0f), new Vector3(18f, 1f, 18f));
+        CreateCube("BackWall", new Vector3(0f, 2f, 5f), new Vector3(18f, 5f, 1f));
+        CreateCube("LeftWall", new Vector3(-8.5f, 2f, 0f), new Vector3(1f, 5f, 10f));
+        CreateCube("RightWall", new Vector3(8.5f, 2f, 0f), new Vector3(1f, 5f, 10f));
+
+        GameObject lightObject = new GameObject("Directional Light");
+        Light light = lightObject.AddComponent<Light>();
+        light.type = LightType.Directional;
+        light.intensity = 1.2f;
+        lightObject.transform.rotation = Quaternion.Euler(50f, -30f, 0f);
+    }
+
+    private static void CreateCube(string name, Vector3 position, Vector3 scale)
+    {
+        GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        cube.name = name;
+        cube.transform.SetPositionAndRotation(position, Quaternion.identity);
+        cube.transform.localScale = scale;
+    }
+
+    private void EnsureStyles()
+    {
+        if (_panelStyle != null) return;
+
+        _panelStyle = new GUIStyle(GUI.skin.box)
+        {
+            padding = new RectOffset(16, 16, 12, 12),
+            fontSize = 18,
+            alignment = TextAnchor.UpperCenter
+        };
+        _buttonStyle = new GUIStyle(GUI.skin.button) { fontSize = 16 };
+        _labelStyle = new GUIStyle(GUI.skin.label)
+        {
+            fontSize = 13,
+            alignment = TextAnchor.MiddleCenter,
+            wordWrap = true
+        };
+    }
+}

--- a/Assets/Scripts/Debug/PlayerDamageReactionTestSceneController.cs.meta
+++ b/Assets/Scripts/Debug/PlayerDamageReactionTestSceneController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1574888b94ec452f8dca9016ec75eab8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Animation/DamagedSMB.cs
+++ b/Assets/Scripts/Player/Animation/DamagedSMB.cs
@@ -8,7 +8,8 @@ public class DamagedSMB : StateMachineBehaviour
 {
     public override void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-        if (animator.TryGetComponent(out PlayerAnimationController controller))
+        PlayerAnimationController controller = animator.GetComponentInParent<PlayerAnimationController>();
+        if (controller != null)
             controller.AnimEvent_DamagedEnd();
     }
 }

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -65,6 +65,8 @@ public class PlayerMovement : MonoBehaviour
     /// </summary>
     public void PlayDamageReaction(DamageReactionType reactionType)
     {
+        CancelDodgeByDamage();
+
         _damageReactionMoveCts?.Cancel();
         _damageReactionMoveCts?.Dispose();
         _damageReactionMoveCts = new CancellationTokenSource();
@@ -420,6 +422,21 @@ public class PlayerMovement : MonoBehaviour
     }
 
     // ── 被弾 ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// 被弾によって回避を中断し、遅れて届く回避終了通知でDamaged状態が解除されるのを防ぐ。
+    /// </summary>
+    private void CancelDodgeByDamage()
+    {
+        if (!_isDodging) return;
+
+        _isDodging = false;
+        _dodgeMoveCts?.Cancel();
+        _dodgeMoveCts?.Dispose();
+        _dodgeMoveCts = null;
+        _rb.linearVelocity = Vector3.zero;
+        OnEndDodge?.Invoke();
+    }
 
     /// <summary>
     /// 被弾アニメーション終了時にDamaged状態を解除する。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * プレイヤーのダメージリアクション（Small／Medium／Large）を手動で確認できるテストシーンを追加しました。
  * リアクション選択後のステータス表示とクールダウン表示に対応しました。
* **改善**
  * 被弾時に回避を中断し、後続処理が正しく反映されるよう改善しました。
  * ダメージ・ノックダウン系のアニメーション遷移と立ち上がり挙動を見直しました。
* **不具合修正**
  * 条件によってダメージ終了処理が実行されない問題を修正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->