### PR TITLE
雷神モードのコンボ中断バグの修正

### DIFF
--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -203,6 +203,10 @@ public class PlayerAttack : MonoBehaviour
     /// </summary>
     private void HandleAttackPressed()
     {
+        // 長押し中に started が再通知されても、新しい攻撃入力として扱わない。
+        // 特に雷神モードでは再通知時点でコンボが終了していると、初段が再生されてしまう。
+        if (_isAttackButtonHeld) return;
+
         // すでにチャージ中なら無視
         if (_isCharging) return;
 

--- a/Assets/Scripts/System/InputHandler.cs
+++ b/Assets/Scripts/System/InputHandler.cs
@@ -31,6 +31,9 @@ public class InputHandler : MonoBehaviour
         }
         else
         {
+            // Disable() による canceled は停止中の入力として無視されるため、
+            // 先に解放を通知して攻撃側の押下状態を同期する。
+            OnLightAttackReleased?.Invoke();
             _isDisablingInput = true;
             MoveInput = Vector2.zero;
             CameraMoveInput = Vector2.zero;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 攻撃ボタンを長押しした際、重複して通知される入力を新たな攻撃として処理しないよう修正しました。
  * 長押し中の不要な攻撃の重複発動を防止します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->