### PR TITLE
スロー再生時にSMBのイベント発火タイミングがずれる問題を修正

### DIFF
--- a/Assets/Scripts/Enemy/Boss/View/SMB/Attack/BaseClass/AttackSMBBase.cs
+++ b/Assets/Scripts/Enemy/Boss/View/SMB/Attack/BaseClass/AttackSMBBase.cs
@@ -36,6 +36,7 @@ namespace BossEnemy.View.SMB
             _isChargeCompleted = false;
             _attackHitFired = false;
             _isAttackAreaActive = false;
+            _stateLength = stateInfo.length;
             PlayBossSE(AttackStartVoiceCueName);
             Debug.Log("アニメーション合計時間：" + stateInfo.length);
         }
@@ -47,13 +48,13 @@ namespace BossEnemy.View.SMB
             if (animator.IsInTransition(layerIndex) && stateInfo.normalizedTime >= 0.5f) return;
 
             // アニメーション開始からの経過秒数計測
-            _elapsedSeconds = stateInfo.normalizedTime * stateInfo.length;
+            _elapsedSeconds = stateInfo.normalizedTime * _stateLength;
 
             AttackSequence(animator, stateInfo, layerIndex);
 
             if (_isAnimRunning)
             {
-                if (stateInfo.length <= _elapsedSeconds)
+                if (_stateLength <= _elapsedSeconds)
                 {
                     _bossAnimator.SetAttacking(false);
                     _isAnimRunning = false;
@@ -134,6 +135,8 @@ namespace BossEnemy.View.SMB
         protected bool _isAttackAreaActive = false;
 
         protected float _elapsedSeconds = 0;
+
+        protected float _stateLength = 0;
 
         protected Transform _bossEnemyTransform;
 

--- a/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackSMB.cs
+++ b/Assets/Scripts/Enemy/Mob/SMB/EnemyAttackSMB.cs
@@ -11,6 +11,7 @@ public class EnemyAttackSMB : StateMachineBehaviour
     {
         _attackHitFired = false;
         _weaponSwingFired = false;
+        _stateLength = stateInfo.length;
 
         if (animator.TryGetComponent(out IEnemyAnimationController controller))
         {
@@ -21,7 +22,7 @@ public class EnemyAttackSMB : StateMachineBehaviour
     public override void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         if (animator.speed == 0f) return;
-        float currentTime = stateInfo.normalizedTime * stateInfo.length;
+        float currentTime = stateInfo.normalizedTime * _stateLength;
 
         // 武器スイングSE
         if (!_weaponSwingFired && currentTime >= _weaponSwingTime)
@@ -59,4 +60,5 @@ public class EnemyAttackSMB : StateMachineBehaviour
 
     private bool _attackHitFired;
     private bool _weaponSwingFired;
+    private float _stateLength;
 }

--- a/Assets/Scripts/Player/Animation/AttackEventSMB.cs
+++ b/Assets/Scripts/Player/Animation/AttackEventSMB.cs
@@ -10,6 +10,7 @@ public class AttackEventSMB : StateMachineBehaviour
         _comboStarted = false;
         _comboEnded = false;
         _attackCompleted = false;
+        _stateLength = stateInfo.length;
 
         animator.TryGetComponent(out _controller);
     }
@@ -20,7 +21,7 @@ public class AttackEventSMB : StateMachineBehaviour
         if (animator.speed == 0f) { return; }
         if (_controller == null) { return; }
 
-        float currentTime = stateInfo.normalizedTime * stateInfo.length;
+        float currentTime = stateInfo.normalizedTime * _stateLength;
 
         for (int i = 0; i < _attackExecuteTimes.Length; i++)
         {
@@ -70,4 +71,5 @@ public class AttackEventSMB : StateMachineBehaviour
     private bool _comboStarted;
     private bool _comboEnded;
     private bool _attackCompleted;
+    private float _stateLength;
 }

--- a/Assets/Scripts/Player/Animation/DodgeSMB.cs
+++ b/Assets/Scripts/Player/Animation/DodgeSMB.cs
@@ -10,6 +10,7 @@ public class DodgeSMB : StateMachineBehaviour
     {
         _invincibilityStarted = false;
         _isDodgeEnded = false;
+        _stateLength = stateInfo.length;
 
         if (animator.TryGetComponent(out PlayerAnimationController controller))
             _playerAnimationController = controller;
@@ -18,7 +19,7 @@ public class DodgeSMB : StateMachineBehaviour
     public override void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         if (_playerAnimationController == null) { return; }
-        float currentTime = stateInfo.normalizedTime * stateInfo.length;
+        float currentTime = stateInfo.normalizedTime * _stateLength;
 
         if (!_invincibilityStarted &&
             currentTime >= _invincibleStartTime)
@@ -51,4 +52,5 @@ public class DodgeSMB : StateMachineBehaviour
     private PlayerAnimationController _playerAnimationController;
     private bool _invincibilityStarted;
     private bool _isDodgeEnded;
+    private float _stateLength;
 }

--- a/Assets/Scripts/Player/Animation/ModeChangeSMB.cs
+++ b/Assets/Scripts/Player/Animation/ModeChangeSMB.cs
@@ -8,6 +8,7 @@ public class ModeChangeSMB : StateMachineBehaviour
         _slowApplied = false;
         _modeChangeEnded = false;
         _modeChangeAnimController = null;
+        _stateLength = stateInfo.length;
 
         ServiceLocator.TryGet(out _hitStopManager);
 
@@ -19,7 +20,7 @@ public class ModeChangeSMB : StateMachineBehaviour
 
     public override void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-        float currentTime = stateInfo.normalizedTime * stateInfo.length;
+        float currentTime = stateInfo.normalizedTime * _stateLength;
 
         if (!_slowApplied && currentTime >= _slowStartTime)
         {
@@ -51,4 +52,5 @@ public class ModeChangeSMB : StateMachineBehaviour
     private IModeChangeAnimationController _modeChangeAnimController;
     private bool _slowApplied;
     private bool _modeChangeEnded;
+    private float _stateLength;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * 攻撃、回避、モード変更などのアニメーション処理を改善しました。
  * アニメーション開始時の長さを基準に経過時間を計算することで、再生中の状態変化による判定ずれを抑制しました。
  * ステート終了判定や攻撃イベントのタイミングが、より安定して動作するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->