### PR TITLE
攻撃SMBにモードチェンジ可能になる時間を追加

### DIFF
--- a/Assets/Scripts/Interface/IAnimationController.cs
+++ b/Assets/Scripts/Interface/IAnimationController.cs
@@ -8,6 +8,7 @@ public interface IAnimationController
     public void AnimEvent_AttackComplete();
     public void AnimEvent_ComboWindowStart();
     public void AnimEvent_ComboWindowEnd();
+    public void AnimEvent_ModeChangeReady();
     public void AnimEvent_ComboTransition();
 }
 

--- a/Assets/Scripts/Player/Animation/AttackEventSMB.cs
+++ b/Assets/Scripts/Player/Animation/AttackEventSMB.cs
@@ -9,6 +9,7 @@ public class AttackEventSMB : StateMachineBehaviour
         _attackExecuted = new bool[_attackExecuteTimes.Length];
         _comboStarted = false;
         _comboEnded = false;
+        _modeChangeReady = false;
         _attackCompleted = false;
         _stateLength = stateInfo.length;
 
@@ -44,6 +45,12 @@ public class AttackEventSMB : StateMachineBehaviour
             _controller.AnimEvent_ComboTransition();
         }
 
+        if (!_modeChangeReady && currentTime >= _modeChangeTime)
+        {
+            _modeChangeReady = true;
+            _controller.AnimEvent_ModeChangeReady();
+        }
+
         if (!_attackCompleted && currentTime >= _attackCompleteTime)
         {
             _attackCompleted = true;
@@ -63,6 +70,8 @@ public class AttackEventSMB : StateMachineBehaviour
     [SerializeField] private float[] _attackExecuteTimes;
     [SerializeField] private float _comboWindowStartTime = 0.35f;
     [SerializeField] private float _comboWindowEndTime = 0.55f;
+    [Tooltip("攻撃中にモードチェンジ入力を受け付け始める時刻（秒）")]
+    [SerializeField] private float _modeChangeTime = 0.7f;
     [SerializeField] private float _attackCompleteTime = 999f;
 
     private IAnimationController _controller;
@@ -70,6 +79,7 @@ public class AttackEventSMB : StateMachineBehaviour
     private bool[] _attackExecuted;
     private bool _comboStarted;
     private bool _comboEnded;
+    private bool _modeChangeReady;
     private bool _attackCompleted;
     private float _stateLength;
 }

--- a/Assets/Scripts/Player/Animation/PlayerAnimationController.cs
+++ b/Assets/Scripts/Player/Animation/PlayerAnimationController.cs
@@ -16,6 +16,7 @@ public class PlayerAnimationController : MonoBehaviour, IAnimationController, IM
     public event Action OnAttackComplete;
     public event Action OnComboWindowStart;
     public event Action OnComboWindowEnd;
+    public event Action OnModeChangeReady;
     public event Action<int, int> OnAttackExecute;
     public event Action OnModeChangeComplete;
     public event Action OnComboTransition;
@@ -34,6 +35,7 @@ public class PlayerAnimationController : MonoBehaviour, IAnimationController, IM
     public void AnimEvent_AttackComplete() => OnAttackComplete?.Invoke();
     public void AnimEvent_ComboWindowStart() => OnComboWindowStart?.Invoke();
     public void AnimEvent_ComboWindowEnd() => OnComboWindowEnd?.Invoke();
+    public void AnimEvent_ModeChangeReady() => OnModeChangeReady?.Invoke();
     public void AnimEvent_ModeChangeComplete() => OnModeChangeComplete?.Invoke();
     public void AnimEvent_ComboTransition() => OnComboTransition?.Invoke();
 

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -911,7 +911,12 @@ public class PlayerAttack : MonoBehaviour
     /// モード変更時の処理。モードが変更されたときにコンボをリセットする。これにより、モード変更後の攻撃が新しいコンボとして始まるようになる。
     /// </summary>
     /// <param name="_">イベントに合わせるためのものなので使用しないが引数を付けている</param>
-    private void OnModeChanged(PlayerMode _) => ResetCombo();
+    private void OnModeChanged(PlayerMode _)
+    {
+        // コンボ中に準備した旧モードのチャージ状態を、モード変更後へ持ち越さない。
+        CancelCharge();
+        ResetCombo();
+    }
 
     /// <summary>
     /// モード変更の入力処理。モード変更が可能な状態であれば、現在のモードに応じて新しいモードに切り替える。雷神モードへの切り替えは即時に行い、闘神モードへの切り替えは状態遷移を伴う。

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -58,6 +58,7 @@ public class PlayerAttack : MonoBehaviour
         _animationController.OnAttackComplete += FinishAttack;
         _animationController.OnComboWindowStart += OnComboWindowStart;
         _animationController.OnComboWindowEnd += OnComboWindowEnd;
+        _animationController.OnModeChangeReady += OnModeChangeReady;
         _animationController.OnComboTransition += TryComboTransition;
         _animationController.OnChargeReady += OnChargeReady;
 
@@ -140,6 +141,7 @@ public class PlayerAttack : MonoBehaviour
     private bool _autoFireTriggered = false;
 
     private bool _isInComboWindow;
+    private bool _canModeChangeDuringAttack;
     private bool _isComboTransitioned;
 
     private bool _isHomingActive;
@@ -186,6 +188,7 @@ public class PlayerAttack : MonoBehaviour
             _animationController.OnAttackComplete -= FinishAttack;
             _animationController.OnComboWindowStart -= OnComboWindowStart;
             _animationController.OnComboWindowEnd -= OnComboWindowEnd;
+            _animationController.OnModeChangeReady -= OnModeChangeReady;
             _animationController.OnComboTransition -= TryComboTransition;
             _animationController.OnChargeReady -= OnChargeReady;
         }
@@ -401,6 +404,7 @@ public class PlayerAttack : MonoBehaviour
         FaceAttackTarget();
         RequestAttackMove(variant, false);
 
+        _canModeChangeDuringAttack = false;
         float transition = variant.TransitionDuration < 0 ? 0.1f : variant.TransitionDuration;
         _animationController.PlayAttackBlend(_currentAttackId, variant.AnimationStateName, transition);
     }
@@ -465,6 +469,7 @@ public class PlayerAttack : MonoBehaviour
         FaceAttackTarget();
         RequestAttackMove(variant, false);
 
+        _canModeChangeDuringAttack = false;
         _stateManager.ChangeState(PlayerState.Attacking);
         float transition = variant.TransitionDuration < 0 ? 0.1f : variant.TransitionDuration;
         _animationController.PlayAttackBlend(_currentAttackId, variant.AnimationStateName, transition);
@@ -490,6 +495,15 @@ public class PlayerAttack : MonoBehaviour
         _pendingAttackData = null;
         _pendingAttackInput = null;
         _activeAttackVariant = null;
+        _canModeChangeDuringAttack = false;
+
+        // モードチェンジによって攻撃アニメーションを抜けた場合は、
+        // モードチェンジ完了通知まで ModeChanging を維持する。
+        if (_stateManager.CurrentState == PlayerState.ModeChanging)
+        {
+            ResetCombo();
+            return;
+        }
 
         if (_pendingWarriorCharge)
         {
@@ -567,6 +581,9 @@ public class PlayerAttack : MonoBehaviour
     /// コンボウィンドウの開始と終了を管理する。コンボウィンドウ中は次の攻撃への入力を受け付ける状態になる。
     /// </summary>
     private void OnComboWindowStart() => _isInComboWindow = true;
+
+    /// <summary>攻撃中のモードチェンジ受付を開始する。</summary>
+    private void OnModeChangeReady() => _canModeChangeDuringAttack = true;
 
     /// <summary>
     /// コンボウィンドウの終了を管理する。コンボウィンドウが終了すると、次の攻撃への入力は受け付けなくなる。
@@ -901,15 +918,11 @@ public class PlayerAttack : MonoBehaviour
     /// </summary>
     private void ChangeMode()
     {
-        if (!_stateManager.CanModeChange()) { return; }
+        bool canChange = _stateManager.CanModeChange()
+            || (_stateManager.CurrentState == PlayerState.Attacking && _canModeChangeDuringAttack);
+        if (!canChange) { return; }
 
         var newMode = _modeController.CurrentMode == PlayerMode.Warrior ? PlayerMode.Thunder : PlayerMode.Warrior;
-
-        if (newMode == PlayerMode.Warrior)
-        {
-            _modeController.SwitchMode(newMode);
-            return;
-        }
 
         _stateManager.ChangeState(PlayerState.ModeChanging);
         _modeController.SwitchMode(newMode);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 攻撃中でも、特定のタイミングでモード変更を受け付けられるようになりました。
  - モード変更の準備完了タイミングがアニメーションと連動するようになりました。

- **改善**
  - 攻撃中にモード変更した場合でも、状態やコンボが正しく処理されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->