### PR TITLE
敵のUI表示位置用のTransformを追加

### DIFF
--- a/Assets/Prefab/Enemy/Mob/Mob_Armor_Heavy.prefab
+++ b/Assets/Prefab/Enemy/Mob/Mob_Armor_Heavy.prefab
@@ -1,5 +1,37 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &710000000000000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 710000000000000002}
+  m_Layer: 0
+  m_Name: UIAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &710000000000000002
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710000000000000001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.8, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2920058799239186866}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+
 --- !u!1 &1992481896671477447
 GameObject:
   m_ObjectHideFlags: 0
@@ -155,6 +187,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 8713508804593366045}
+  - {fileID: 710000000000000002}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &8631267147205945289
@@ -194,6 +227,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::MobEnemy
   _data: {fileID: 11400000, guid: 5e54c5ca47ea8cd45b9052148ab3e0fa, type: 2}
   _targetCenter: {fileID: 1948534881891661956}
+  _uiAnchor: {fileID: 710000000000000002}
   _movementCollider: {fileID: 0}
   _animator: {fileID: 3318227978134711911}
   _turnProfile: {fileID: 11400000, guid: 362aa867931ba5444ae43e73f8223e3e, type: 2}

--- a/Assets/Prefab/Enemy/Mob/Mob_Armor_Ligth.prefab
+++ b/Assets/Prefab/Enemy/Mob/Mob_Armor_Ligth.prefab
@@ -1,37 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &710000000000000011
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 710000000000000012}
-  m_Layer: 0
-  m_Name: UIAnchor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &710000000000000012
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 710000000000000011}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.8, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4768063558428433756}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-
 --- !u!1 &153920042580441905
 GameObject:
   m_ObjectHideFlags: 0
@@ -122,6 +90,37 @@ MeshRenderer:
   m_SortingOrder: 0
   m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &710000000000000011
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 710000000000000012}
+  m_Layer: 0
+  m_Name: UIAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &710000000000000012
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710000000000000011}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.8, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4768063558428433756}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3801929445349576463
 GameObject:
   m_ObjectHideFlags: 0
@@ -196,7 +195,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::MobEnemy
   _data: {fileID: 11400000, guid: b23e753ca7b585b4a9bc2adb6b749ee5, type: 2}
   _targetCenter: {fileID: 6137507949253905296}
-  _uiAnchor: {fileID: 710000000000000012}
   _movementCollider: {fileID: 0}
   _animator: {fileID: 7840218667852355449}
   _turnProfile: {fileID: 11400000, guid: 362aa867931ba5444ae43e73f8223e3e, type: 2}
@@ -207,6 +205,7 @@ MonoBehaviour:
   _useSpawnEffect: 1
   _spawnEffectKey: "\u30B9\u30DD\u30FC\u30F3\u30A8\u30D5\u30A7\u30AF\u30C8"
   _armor: {fileID: 1602763633999352537}
+  _uiAnchor: {fileID: 710000000000000012}
 --- !u!114 &3406474487311268722
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefab/Enemy/Mob/Mob_Armor_Ligth.prefab
+++ b/Assets/Prefab/Enemy/Mob/Mob_Armor_Ligth.prefab
@@ -1,5 +1,37 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &710000000000000011
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 710000000000000012}
+  m_Layer: 0
+  m_Name: UIAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &710000000000000012
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710000000000000011}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.8, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4768063558428433756}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+
 --- !u!1 &153920042580441905
 GameObject:
   m_ObjectHideFlags: 0
@@ -124,6 +156,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 4192325146830441731}
+  - {fileID: 710000000000000012}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &7469027508442278846
@@ -163,6 +196,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::MobEnemy
   _data: {fileID: 11400000, guid: b23e753ca7b585b4a9bc2adb6b749ee5, type: 2}
   _targetCenter: {fileID: 6137507949253905296}
+  _uiAnchor: {fileID: 710000000000000012}
   _movementCollider: {fileID: 0}
   _animator: {fileID: 7840218667852355449}
   _turnProfile: {fileID: 11400000, guid: 362aa867931ba5444ae43e73f8223e3e, type: 2}

--- a/Assets/Prefab/Enemy/Mob/Mob_Armor_Medium.prefab
+++ b/Assets/Prefab/Enemy/Mob/Mob_Armor_Medium.prefab
@@ -1,5 +1,37 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &710000000000000021
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 710000000000000022}
+  m_Layer: 0
+  m_Name: UIAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &710000000000000022
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710000000000000021}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.8, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1162169414862588232}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+
 --- !u!1 &2331296349192890590
 GameObject:
   m_ObjectHideFlags: 0
@@ -155,6 +187,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 2476724197443376710}
+  - {fileID: 710000000000000022}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &8349339655285426767
@@ -194,6 +227,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::MobEnemy
   _data: {fileID: 11400000, guid: 5e54c5ca47ea8cd45b9052148ab3e0fa, type: 2}
   _targetCenter: {fileID: 3965120662585892537}
+  _uiAnchor: {fileID: 710000000000000022}
   _movementCollider: {fileID: 0}
   _animator: {fileID: 8412507901956443196}
   _turnProfile: {fileID: 11400000, guid: 362aa867931ba5444ae43e73f8223e3e, type: 2}

--- a/Assets/Prefab/Enemy/Mob/Mob_Heavy.prefab
+++ b/Assets/Prefab/Enemy/Mob/Mob_Heavy.prefab
@@ -1,5 +1,37 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &710000000000000031
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 710000000000000032}
+  m_Layer: 0
+  m_Name: UIAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &710000000000000032
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710000000000000031}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.8, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4005547831478789751}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+
 --- !u!1 &839366897471280499
 GameObject:
   m_ObjectHideFlags: 0
@@ -34,6 +66,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 4859117597278908734}
+  - {fileID: 710000000000000032}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &8178910185839973620
@@ -73,6 +106,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::MobEnemy
   _data: {fileID: 11400000, guid: 5e54c5ca47ea8cd45b9052148ab3e0fa, type: 2}
   _targetCenter: {fileID: 3366854651423494619}
+  _uiAnchor: {fileID: 710000000000000032}
   _movementCollider: {fileID: 0}
   _animator: {fileID: 1553497098150046532}
   _turnProfile: {fileID: 11400000, guid: 362aa867931ba5444ae43e73f8223e3e, type: 2}

--- a/Assets/Prefab/Enemy/Mob/Mob_Ligth.prefab
+++ b/Assets/Prefab/Enemy/Mob/Mob_Ligth.prefab
@@ -1,5 +1,37 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &710000000000000041
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 710000000000000042}
+  m_Layer: 0
+  m_Name: UIAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &710000000000000042
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710000000000000041}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.8, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5724185230764040236}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+
 --- !u!1 &12694304601248119
 GameObject:
   m_ObjectHideFlags: 0
@@ -282,6 +314,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 308418088623837340}
+  - {fileID: 710000000000000042}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &2242823858591136518
@@ -321,6 +354,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::MobEnemy
   _data: {fileID: 11400000, guid: b23e753ca7b585b4a9bc2adb6b749ee5, type: 2}
   _targetCenter: {fileID: 4147938950973546549}
+  _uiAnchor: {fileID: 710000000000000042}
   _movementCollider: {fileID: 0}
   _animator: {fileID: 5955892080248572646}
   _turnProfile: {fileID: 11400000, guid: 362aa867931ba5444ae43e73f8223e3e, type: 2}

--- a/Assets/Prefab/Enemy/Mob/Mob_Medium.prefab
+++ b/Assets/Prefab/Enemy/Mob/Mob_Medium.prefab
@@ -1,5 +1,37 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &710000000000000051
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 710000000000000052}
+  m_Layer: 0
+  m_Name: UIAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &710000000000000052
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710000000000000051}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.8, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 870015816442665258}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+
 --- !u!1 &329482191508721452
 GameObject:
   m_ObjectHideFlags: 0
@@ -155,6 +187,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 536626424693038596}
+  - {fileID: 710000000000000052}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &7671823680619389335
@@ -194,6 +227,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::MobEnemy
   _data: {fileID: 11400000, guid: b2c2fedc4750d4e40bca31fbc8e4d405, type: 2}
   _targetCenter: {fileID: 3281268376374684823}
+  _uiAnchor: {fileID: 710000000000000052}
   _movementCollider: {fileID: 0}
   _animator: {fileID: 5877855259398194302}
   _turnProfile: {fileID: 11400000, guid: 362aa867931ba5444ae43e73f8223e3e, type: 2}

--- a/Assets/Prefab/Enemy/Mob/StoneGolem.prefab
+++ b/Assets/Prefab/Enemy/Mob/StoneGolem.prefab
@@ -1,5 +1,36 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &710000000000000061
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 710000000000000062}
+  m_Layer: 0
+  m_Name: UIAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &710000000000000062
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710000000000000061}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.59, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1086601411383579548}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &9180035382195313
 GameObject:
   m_ObjectHideFlags: 0
@@ -377,6 +408,7 @@ Transform:
   - {fileID: 3668744915720423143}
   - {fileID: 6348492763003575672}
   - {fileID: 8403906461536326491}
+  - {fileID: 710000000000000062}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7301585828367876861
@@ -393,6 +425,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::GolemEnemy
   _data: {fileID: 11400000, guid: 553d85ef70ae02447a15677d0ecebe52, type: 2}
   _targetCenter: {fileID: 8403906461536326491}
+  _uiAnchor: {fileID: 710000000000000062}
   _movementCollider: {fileID: 0}
   _animator: {fileID: 4821917941713793549}
   _turnProfile: {fileID: 11400000, guid: 84c85403bc40a3c47b61cd25c0d667a0, type: 2}

--- a/Assets/Prefab/Enemy/Mob/StoneGolem.prefab
+++ b/Assets/Prefab/Enemy/Mob/StoneGolem.prefab
@@ -1,36 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &710000000000000061
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 710000000000000062}
-  m_Layer: 0
-  m_Name: UIAnchor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &710000000000000062
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 710000000000000061}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.59, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1086601411383579548}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &9180035382195313
 GameObject:
   m_ObjectHideFlags: 0
@@ -425,7 +394,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::GolemEnemy
   _data: {fileID: 11400000, guid: 553d85ef70ae02447a15677d0ecebe52, type: 2}
   _targetCenter: {fileID: 8403906461536326491}
-  _uiAnchor: {fileID: 710000000000000062}
   _movementCollider: {fileID: 0}
   _animator: {fileID: 4821917941713793549}
   _turnProfile: {fileID: 11400000, guid: 84c85403bc40a3c47b61cd25c0d667a0, type: 2}
@@ -436,6 +404,7 @@ MonoBehaviour:
   _useSpawnEffect: 1
   _spawnEffectKey: "\u30B9\u30DD\u30FC\u30F3\u30A8\u30D5\u30A7\u30AF\u30C8"
   _armor: {fileID: 2232957639341954153}
+  _uiAnchor: {fileID: 710000000000000062}
   _downDuration: 7
   _bodyRenderer:
   - {fileID: 2179570851823708453}
@@ -674,6 +643,37 @@ Transform:
   m_Children:
   - {fileID: 6796780468124760211}
   m_Father: {fileID: 4866830284739750239}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &710000000000000061
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 710000000000000062}
+  m_Layer: 0
+  m_Name: UIAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &710000000000000062
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710000000000000061}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 2.127, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1086601411383579548}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &732808829483817772
 GameObject:

--- a/Assets/Prefab/UI/EnemyArmerHPGauge.prefab
+++ b/Assets/Prefab/UI/EnemyArmerHPGauge.prefab
@@ -180,7 +180,6 @@ MonoBehaviour:
   _animationDuration: 0.4
   _animationDelay: 0.4
   _animationEase: 1
-  _verticalOffset: 1
 --- !u!114 &8518284488561359063 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5888138155191040375, guid: 2eca31ca8731fcf4cab567c0e3b590d8, type: 3}

--- a/Assets/Prefab/UI/EnemyHPGauge.prefab
+++ b/Assets/Prefab/UI/EnemyHPGauge.prefab
@@ -168,7 +168,6 @@ MonoBehaviour:
   _animationDuration: 0.4
   _animationDelay: 0.4
   _animationEase: 1
-  _verticalOffset: 1
 --- !u!114 &8518284488561359063 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5888138155191040375, guid: 2eca31ca8731fcf4cab567c0e3b590d8, type: 3}

--- a/Assets/Scripts/Enemy/Mob/MobEnemy.cs
+++ b/Assets/Scripts/Enemy/Mob/MobEnemy.cs
@@ -27,6 +27,18 @@ public class MobEnemy : Enemy,IFormationParticipant
         return _armor != null && _defenceContext.EnemyType == EnemyDefenceType.Armor;
     }
 
+    /// <summary>
+    /// Mobのroot直下に固定されたゲージ表示用Transformを返す。
+    /// 初期位置だけTargetCenterに合わせ、Animator配下のモーションには追従させない。
+    /// </summary>
+    public Transform GetUIAnchor()
+    {
+        if (_uiAnchor != null) return _uiAnchor;
+
+        Debug.LogWarning($"{name}: UIAnchorが未設定です。TargetCenterを使用します。", this);
+        return GetTargetCenter();
+    }
+
     // ─── IFormationParticipant ───────────────────────────────────────────
     public int EnemyId => GetInstanceID();
     public float CombatPower => _data != null ? _data.CombatPower : 0f;
@@ -197,6 +209,9 @@ public class MobEnemy : Enemy,IFormationParticipant
 
     // Armorの登録
     [SerializeField] protected MobArmor _armor;
+
+    [SerializeField, Tooltip("root直下に配置するゲージUI用の固定Transform")]
+    private Transform _uiAnchor;
 
     protected EnemyBehaviourRunner _runner;
     private EnemyRuntimeContext _context;

--- a/Assets/Scripts/System/EnemyUIManager.cs
+++ b/Assets/Scripts/System/EnemyUIManager.cs
@@ -91,6 +91,7 @@ public class EnemyUIManager : MonoBehaviour
             enemy,
             view,
             gaugeTarget,
+            enemy.GetTargetCenter(),
             _playerTransform,
             _detectionRange,
             _damagedDisplayDuration
@@ -160,6 +161,7 @@ public class EnemyUIManager : MonoBehaviour
             armor,
             view,
             enemy is MobEnemy mob ? mob.GetUIAnchor() : enemy.GetTargetCenter(),
+            enemy.GetTargetCenter(),
             _playerTransform,
             _detectionRange,
             _damagedDisplayDuration

--- a/Assets/Scripts/System/EnemyUIManager.cs
+++ b/Assets/Scripts/System/EnemyUIManager.cs
@@ -83,10 +83,14 @@ public class EnemyUIManager : MonoBehaviour
     {
         // Gauge
         var view = _gaugePool.Get();
+        Transform gaugeTarget = enemy is MobEnemy mobEnemy
+            ? mobEnemy.GetUIAnchor()
+            : enemy.GetTargetCenter();
 
         var presenter = new EnemyGaugePresenter(
             enemy,
             view,
+            gaugeTarget,
             _playerTransform,
             _detectionRange,
             _damagedDisplayDuration
@@ -155,7 +159,7 @@ public class EnemyUIManager : MonoBehaviour
         var presenter = new ArmorGaugePresenter(
             armor,
             view,
-            enemy.GetTargetCenter(),
+            enemy is MobEnemy mob ? mob.GetUIAnchor() : enemy.GetTargetCenter(),
             _playerTransform,
             _detectionRange,
             _damagedDisplayDuration

--- a/Assets/Scripts/UI/Enemy/EnemyGaugePresenter.cs
+++ b/Assets/Scripts/UI/Enemy/EnemyGaugePresenter.cs
@@ -9,6 +9,7 @@ public class EnemyGaugePresenter : IDisposable
         IEnemy enemy,
         EnemyGaugeView view,
         Transform gaugeTarget,
+        Transform rangeCheckTarget,
         Transform playerTransform,
         float detectionRange,
         float damagedDisplayDuration)
@@ -16,12 +17,12 @@ public class EnemyGaugePresenter : IDisposable
         _enemy = enemy;
         _playerTransform = playerTransform;
         _detectionRange = detectionRange;
-        _enemyTransform = gaugeTarget;
+        _rangeCheckTarget = rangeCheckTarget;
 
         _visibility = new EnemyGaugeVisibilityState(damagedDisplayDuration);
 
         View = view;
-        View.Initialize(_enemyTransform, isBehind => _visibility.SetBehindCamera(isBehind));
+        View.Initialize(gaugeTarget, isBehind => _visibility.SetBehindCamera(isBehind));
 
         _visibility.OnVisibilityChanged += View.SetVisible;
 
@@ -37,8 +38,8 @@ public class EnemyGaugePresenter : IDisposable
     /// <summary>距離チェック。EnemyUIManagerのUpdateから呼ぶ</summary>
     public void UpdateRangeCheck()
     {
-        if (_playerTransform == null || _enemyTransform == null) return;
-        float sqrDist = (_playerTransform.position - _enemyTransform.position).sqrMagnitude;
+        if (_playerTransform == null || _rangeCheckTarget == null) return;
+        float sqrDist = (_playerTransform.position - _rangeCheckTarget.position).sqrMagnitude;
         _visibility.SetInRange(sqrDist <= _detectionRange * _detectionRange);
     }
 
@@ -57,7 +58,7 @@ public class EnemyGaugePresenter : IDisposable
 
     private readonly IEnemy _enemy;
     private readonly Transform _playerTransform;
-    private readonly Transform _enemyTransform;
+    private readonly Transform _rangeCheckTarget;
     private readonly float _detectionRange;
     private readonly EnemyGaugeVisibilityState _visibility;
 
@@ -83,6 +84,7 @@ public class ArmorGaugePresenter : IDisposable
         IArmorHealth armor,
         EnemyGaugeView view,
         Transform gaugeTarget,
+        Transform rangeCheckTarget,
         Transform playerTransform,
         float detectionRange,
         float damagedDisplayDuration)
@@ -92,6 +94,7 @@ public class ArmorGaugePresenter : IDisposable
         _detectionRange = detectionRange;
         // HPゲージと同じEnemy基準位置を使い、2本のゲージを重ねて表示する。
         _gaugeTarget = gaugeTarget;
+        _rangeCheckTarget = rangeCheckTarget;
 
         _visibility = new EnemyGaugeVisibilityState(damagedDisplayDuration);
 
@@ -106,8 +109,8 @@ public class ArmorGaugePresenter : IDisposable
 
     public void UpdateRangeCheck()
     {
-        if (_playerTransform == null || _gaugeTarget == null) return;
-        float sqrDist = (_playerTransform.position - _gaugeTarget.position).sqrMagnitude;
+        if (_playerTransform == null || _rangeCheckTarget == null) return;
+        float sqrDist = (_playerTransform.position - _rangeCheckTarget.position).sqrMagnitude;
         _visibility.SetInRange(sqrDist <= _detectionRange * _detectionRange);
     }
 
@@ -124,6 +127,7 @@ public class ArmorGaugePresenter : IDisposable
     private readonly IArmorHealth _armor;
     private readonly Transform _playerTransform;
     private readonly Transform _gaugeTarget;
+    private readonly Transform _rangeCheckTarget;
     private readonly float _detectionRange;
     private readonly EnemyGaugeVisibilityState _visibility;
 

--- a/Assets/Scripts/UI/Enemy/EnemyGaugePresenter.cs
+++ b/Assets/Scripts/UI/Enemy/EnemyGaugePresenter.cs
@@ -8,6 +8,7 @@ public class EnemyGaugePresenter : IDisposable
     public EnemyGaugePresenter(
         IEnemy enemy,
         EnemyGaugeView view,
+        Transform gaugeTarget,
         Transform playerTransform,
         float detectionRange,
         float damagedDisplayDuration)
@@ -15,7 +16,7 @@ public class EnemyGaugePresenter : IDisposable
         _enemy = enemy;
         _playerTransform = playerTransform;
         _detectionRange = detectionRange;
-        _enemyTransform = enemy.GetTargetCenter();
+        _enemyTransform = gaugeTarget;
 
         _visibility = new EnemyGaugeVisibilityState(damagedDisplayDuration);
 

--- a/Assets/Scripts/UI/Enemy/EnemyGaugeView.cs
+++ b/Assets/Scripts/UI/Enemy/EnemyGaugeView.cs
@@ -70,7 +70,6 @@ public class EnemyGaugeView : MonoBehaviour, IPoolable
     [SerializeField] private float _animationDuration = 0.4f;
     [SerializeField] private float _animationDelay = 0.4f;
     [SerializeField] private Ease _animationEase = Ease.Linear;
-    [SerializeField] private float _verticalOffset = 50f;
 
     private Sequence _delaySequence;
     private Transform _linkEnemy;
@@ -108,7 +107,6 @@ public class EnemyGaugeView : MonoBehaviour, IPoolable
             if (_linkEnemy == null || _mainCamera == null) continue;
 
             var screenPos = _mainCamera.WorldToScreenPoint(_linkEnemy.position);
-            screenPos.y += _verticalOffset;
             bool isBehind = screenPos.z < 0;
 
             if (_isBehindCamera != isBehind)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 敵や鎧のゲージ表示位置を、対象ごとに設定されたアンカーへ配置できるようになりました。
  * モブ敵のゲージが、より適切な位置に表示されるようになりました。
  * ゲージ表示の不要な縦方向オフセットを廃止し、対象位置に直接追従するよう改善しました。
  * アンカー未設定時も、従来の位置を使用して表示を継続します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->